### PR TITLE
Fix invalid wasm-opt detection

### DIFF
--- a/account-wasm/build.sh
+++ b/account-wasm/build.sh
@@ -3,10 +3,7 @@
 set -ex
 
 # Ensure wasm-opt is installed
-if
-    ! command -v wasm-opt &
-    >/dev/null
-then
+if ! command -v wasm-opt &>/dev/null; then
     echo "Installing wasm-opt..."
     npm install -g wasm-opt
 fi


### PR DESCRIPTION
The current `build.sh` script contains an error in `wasm-opt` command detection. The line `! command -v wasm-opt &` always returns `false`, causing `npm install -g wasm-opt` to always run on each invocation.