### PR TITLE
feat: upgrade Starknet JSON-RPC to 0.9.0-rc2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/dojoengine/katana:v1.6.0-alpha.1
+      image: ghcr.io/dojoengine/katana:v1.7.0-alpha.0
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,19 @@ primitive-types = { version = "0.12", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 rand = { version = "0.8", features = ["getrandom"] }
 reqwest = { version = "0.11.16", default-features = false, features = [
-    "json",
-    "rustls-tls",
-    "cookies",
+	"json",
+	"rustls-tls",
+	"cookies",
 ] }
 serde = { version = "1.0.160", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.96", default-features = false, features = [
-    "alloc",
-    "raw_value",
+	"alloc",
+	"raw_value",
 ] }
 serde-wasm-bindgen = "0.6.5"
 serde_with = { version = "3.9.0", default-features = false, features = [
-    "alloc",
-    "macros",
+	"alloc",
+	"macros",
 ] }
 sha2 = "0.10"
 thiserror = "1"
@@ -56,16 +56,15 @@ serde_cbor_2 = { version = "0.12.0-dev" }
 webauthn-rs-core = { git = "https://github.com/cartridge-gg/webauthn-rs", rev = "a6cea88" }
 webauthn-rs-proto = { git = "https://github.com/cartridge-gg/webauthn-rs", rev = "a6cea88" }
 webauthn-authenticator-rs = { git = "https://github.com/cartridge-gg/webauthn-rs", rev = "a6cea88", features = [
-    "softpasskey",
+	"softpasskey",
 ] }
 
-cainome = { git = "https://github.com/cartridge-gg/cainome", version = "0.9.0", features = [
-    "abigen-rs",
-] }
-cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", version = "0.3.0" }
+# TODO: use the official version once this PR is merged: <https://github.com/cartridge-gg/cainome/pull/108>
+cainome = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9" }
 
-starknet = "0.16.0"
-starknet-crypto = { version = "0.7.3", features = ["pedersen_no_lookup"] }
+starknet = "0.17.0-rc.2"
+starknet-crypto = { version = "0.7.4", features = ["pedersen_no_lookup"] }
 starknet-types-core = { version = "0.1", features = ["curve", "hash"] }
 
 chrono = { version = "0.4", features = ["wasmbind", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,8 @@ webauthn-authenticator-rs = { git = "https://github.com/cartridge-gg/webauthn-rs
 	"softpasskey",
 ] }
 
-# TODO: use the official version once this PR is merged: <https://github.com/cartridge-gg/cainome/pull/108>
-cainome = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9" }
+cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }
 
 starknet = "0.17.0-rc.2"
 starknet-crypto = { version = "0.7.4", features = ["pedersen_no_lookup"] }

--- a/account-wasm/src/account.rs
+++ b/account-wasm/src/account.rs
@@ -638,7 +638,7 @@ impl CartridgeAccount {
         let mut controller = self.controller.lock().await;
 
         let provider = controller.provider();
-        let block_id = BlockId::Tag(BlockTag::Pending);
+        let block_id = BlockId::Tag(BlockTag::PreConfirmed);
 
         let mut to_revoke = vec![];
         for session in sessions.clone() {

--- a/account-wasm/src/errors.rs
+++ b/account-wasm/src/errors.rs
@@ -58,6 +58,8 @@ pub enum ErrorCode {
     StarknetUnsupportedContractClassVersion = 62,
     StarknetUnexpectedError = 63,
     StarknetNoTraceAvailable = 10,
+    StarknetReplacementTransactionUnderpriced = 64,
+    StarknetFeeBelowMinimum = 65,
 
     // Custom errors (101 and onwards)
     SignError = 101,
@@ -324,6 +326,16 @@ impl From<ProviderError> for JsControllerError {
 impl From<StarknetError> for JsControllerError {
     fn from(e: StarknetError) -> Self {
         let (code, message, data) = match e {
+            StarknetError::ReplacementTransactionUnderpriced => (
+                ErrorCode::StarknetReplacementTransactionUnderpriced,
+                "Replacement transaction is underpriced",
+                None,
+            ),
+            StarknetError::FeeBelowMinimum => (
+                ErrorCode::StarknetFeeBelowMinimum,
+                "Transaction fee below minimum",
+                None,
+            ),
             StarknetError::FailedToReceiveTransaction => (
                 ErrorCode::StarknetFailedToReceiveTransaction,
                 "Failed to write transaction",
@@ -393,10 +405,10 @@ impl From<StarknetError> for JsControllerError {
                 "Class already declared",
                 None,
             ),
-            StarknetError::InvalidTransactionNonce => (
+            StarknetError::InvalidTransactionNonce(msg) => (
                 ErrorCode::StarknetInvalidTransactionNonce,
                 "Invalid transaction nonce",
-                None,
+                Some(msg),
             ),
             StarknetError::InsufficientResourcesForValidate => (
                 ErrorCode::StarknetInsufficientMaxFee,

--- a/account-wasm/src/types/estimate.rs
+++ b/account-wasm/src/types/estimate.rs
@@ -34,7 +34,6 @@ pub struct JsFeeEstimate {
     pub l1_data_gas_consumed: u64,
     pub l1_data_gas_price: u128,
     pub overall_fee: u128,
-    pub unit: JsPriceUnit,
 }
 
 impl From<JsFeeEstimate> for FeeEstimate {
@@ -47,7 +46,6 @@ impl From<JsFeeEstimate> for FeeEstimate {
             l1_data_gas_consumed: estimate.l1_data_gas_consumed,
             l1_data_gas_price: estimate.l1_data_gas_price,
             overall_fee: estimate.overall_fee,
-            unit: estimate.unit.into(),
         }
     }
 }
@@ -62,7 +60,6 @@ impl From<FeeEstimate> for JsFeeEstimate {
             l1_data_gas_consumed: estimate.l1_data_gas_consumed,
             l1_data_gas_price: estimate.l1_data_gas_price,
             overall_fee: estimate.overall_fee,
-            unit: estimate.unit.into(),
         }
     }
 }
@@ -101,7 +98,6 @@ mod tests {
             l1_data_gas_consumed: 0,
             l1_data_gas_price: 0,
             overall_fee: 0,
-            unit: JsPriceUnit::Fri,
         };
 
         // Test conversion to FeeEstimate
@@ -114,7 +110,6 @@ mod tests {
         assert_eq!(fee_estimate.l1_data_gas_consumed, 0);
         assert_eq!(fee_estimate.l1_data_gas_price, 0);
         assert_eq!(fee_estimate.overall_fee, 0);
-        assert_eq!(fee_estimate.unit, PriceUnit::Fri);
 
         // Test conversion back to JsFeeEstimate
         let converted_back: JsFeeEstimate = fee_estimate.into();
@@ -126,7 +121,6 @@ mod tests {
         assert_eq!(converted_back.l1_data_gas_consumed, 0);
         assert_eq!(converted_back.l1_data_gas_price, 0);
         assert_eq!(converted_back.overall_fee, 0);
-        assert_eq!(converted_back.unit, JsPriceUnit::Fri);
     }
 
     #[test]

--- a/account_sdk/Cargo.toml
+++ b/account_sdk/Cargo.toml
@@ -66,7 +66,7 @@ serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
-alloy-primitives = "0.8.23"
+alloy-primitives = "0.8"
 alloy-signer.workspace = true
 rand = "0.8"
 

--- a/account_sdk/src/abigen/controller.rs
+++ b/account_sdk/src/abigen/controller.rs
@@ -16,7 +16,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         Self {
             address,
             account,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {
@@ -43,7 +45,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         Self {
             address,
             provider,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {

--- a/account_sdk/src/abigen/controller.rs
+++ b/account_sdk/src/abigen/controller.rs
@@ -75,23 +75,22 @@ impl cainome::cairo_serde::CairoSerde for Call {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.to);
+        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.to);
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.selector);
-        __size
-            += Vec::<
-                starknet::core::types::Felt,
-            >::cairo_serialized_size(&__rust.calldata);
+        __size += Vec::<starknet::core::types::Felt>::cairo_serialized_size(&__rust.calldata);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.to));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.selector));
-        __out
-            .extend(
-                Vec::<starknet::core::types::Felt>::cairo_serialize(&__rust.calldata),
-            );
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            &__rust.to,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.selector,
+        ));
+        __out.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            &__rust.calldata,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -99,21 +98,17 @@ impl cainome::cairo_serde::CairoSerde for Call {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let to = cainome::cairo_serde::ContractAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let to = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
         __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&to);
-        let selector = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let selector = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&selector);
-        let calldata = Vec::<
-            starknet::core::types::Felt,
-        >::cairo_deserialize(__felts, __offset)?;
+        let calldata = Vec::<starknet::core::types::Felt>::cairo_deserialize(__felts, __offset)?;
         __offset += Vec::<starknet::core::types::Felt>::cairo_serialized_size(&calldata);
-        Ok(Call { to, selector, calldata })
+        Ok(Call {
+            to,
+            selector,
+            calldata,
+        })
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -126,18 +121,14 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountChanged {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                &__rust.address,
-            );
+        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
-            );
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            &__rust.address,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -145,12 +136,8 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountChanged {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(DelegateAccountChanged { address })
     }
 }
@@ -172,18 +159,14 @@ impl cainome::cairo_serde::CairoSerde for Eip191Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::EthAddress::cairo_serialized_size(
-                &__rust.eth_address,
-            );
+        __size += cainome::cairo_serde::EthAddress::cairo_serialized_size(&__rust.eth_address);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::EthAddress::cairo_serialize(&__rust.eth_address),
-            );
+        __out.extend(cainome::cairo_serde::EthAddress::cairo_serialize(
+            &__rust.eth_address,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -191,12 +174,8 @@ impl cainome::cairo_serde::CairoSerde for Eip191Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let eth_address = cainome::cairo_serde::EthAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::EthAddress::cairo_serialized_size(&eth_address);
+        let eth_address = cainome::cairo_serde::EthAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::EthAddress::cairo_serialized_size(&eth_address);
         Ok(Eip191Signer { eth_address })
     }
 }
@@ -210,18 +189,14 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRegistered {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                &__rust.address,
-            );
+        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
-            );
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            &__rust.address,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -229,12 +204,8 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRegistered {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(ExternalOwnerRegistered { address })
     }
 }
@@ -256,18 +227,14 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRemoved {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                &__rust.address,
-            );
+        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
-            );
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            &__rust.address,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -275,12 +242,8 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRemoved {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(ExternalOwnerRemoved { address })
     }
 }
@@ -318,15 +281,8 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                &__rust.caller,
-            );
-        __size
-            += <(
-                starknet::core::types::Felt,
-                u128,
-            )>::cairo_serialized_size(&__rust.nonce);
+        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.caller);
+        __size += <(starknet::core::types::Felt, u128)>::cairo_serialized_size(&__rust.nonce);
         __size += u64::cairo_serialized_size(&__rust.execute_after);
         __size += u64::cairo_serialized_size(&__rust.execute_before);
         __size += Vec::<Call>::cairo_serialized_size(&__rust.calls);
@@ -334,14 +290,12 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.caller),
-            );
-        __out
-            .extend(
-                <(starknet::core::types::Felt, u128)>::cairo_serialize(&__rust.nonce),
-            );
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            &__rust.caller,
+        ));
+        __out.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
+            &__rust.nonce,
+        ));
         __out.extend(u64::cairo_serialize(&__rust.execute_after));
         __out.extend(u64::cairo_serialize(&__rust.execute_before));
         __out.extend(Vec::<Call>::cairo_serialize(&__rust.calls));
@@ -352,16 +306,9 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let caller = cainome::cairo_serde::ContractAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&caller);
-        let nonce = <(
-            starknet::core::types::Felt,
-            u128,
-        )>::cairo_deserialize(__felts, __offset)?;
+        let caller = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&caller);
+        let nonce = <(starknet::core::types::Felt, u128)>::cairo_deserialize(__felts, __offset)?;
         __offset += <(starknet::core::types::Felt, u128)>::cairo_serialized_size(&nonce);
         let execute_after = u64::cairo_deserialize(__felts, __offset)?;
         __offset += u64::cairo_serialized_size(&execute_after);
@@ -460,18 +407,14 @@ impl cainome::cairo_serde::CairoSerde for Secp256k1Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::EthAddress::cairo_serialized_size(
-                &__rust.pubkey_hash,
-            );
+        __size += cainome::cairo_serde::EthAddress::cairo_serialized_size(&__rust.pubkey_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::EthAddress::cairo_serialize(&__rust.pubkey_hash),
-            );
+        __out.extend(cainome::cairo_serde::EthAddress::cairo_serialize(
+            &__rust.pubkey_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -479,12 +422,8 @@ impl cainome::cairo_serde::CairoSerde for Secp256k1Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey_hash = cainome::cairo_serde::EthAddress::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += cainome::cairo_serde::EthAddress::cairo_serialized_size(&pubkey_hash);
+        let pubkey_hash = cainome::cairo_serde::EthAddress::cairo_deserialize(__felts, __offset)?;
+        __offset += cainome::cairo_serde::EthAddress::cairo_serialized_size(&pubkey_hash);
         Ok(Secp256k1Signer { pubkey_hash })
     }
 }
@@ -498,20 +437,19 @@ impl cainome::cairo_serde::CairoSerde for Secp256r1Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&__rust.pubkey);
+        __size +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &__rust.pubkey,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::NonZero::<
-                    cainome::cairo_serde::U256,
-                >::cairo_serialize(&__rust.pubkey),
-            );
+        __out.extend(
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
+                &__rust.pubkey,
+            ),
+        );
         __out
     }
     fn cairo_deserialize(
@@ -519,13 +457,14 @@ impl cainome::cairo_serde::CairoSerde for Secp256r1Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey = cainome::cairo_serde::NonZero::<
-            cainome::cairo_serde::U256,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&pubkey);
+        let pubkey =
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
+                __felts, __offset,
+            )?;
+        __offset +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &pubkey,
+            );
         Ok(Secp256r1Signer { pubkey })
     }
 }
@@ -548,41 +487,27 @@ impl cainome::cairo_serde::CairoSerde for Session {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += u64::cairo_serialized_size(&__rust.expires_at);
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(
-                &__rust.allowed_policies_root,
-            );
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(&__rust.metadata_hash);
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(
-                &__rust.session_key_guid,
-            );
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(
-                &__rust.guardian_key_guid,
-            );
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.allowed_policies_root);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.metadata_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_key_guid);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.guardian_key_guid);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(u64::cairo_serialize(&__rust.expires_at));
-        __out
-            .extend(
-                starknet::core::types::Felt::cairo_serialize(
-                    &__rust.allowed_policies_root,
-                ),
-            );
-        __out
-            .extend(starknet::core::types::Felt::cairo_serialize(&__rust.metadata_hash));
-        __out
-            .extend(
-                starknet::core::types::Felt::cairo_serialize(&__rust.session_key_guid),
-            );
-        __out
-            .extend(
-                starknet::core::types::Felt::cairo_serialize(&__rust.guardian_key_guid),
-            );
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.allowed_policies_root,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.metadata_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.session_key_guid,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.guardian_key_guid,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -592,31 +517,15 @@ impl cainome::cairo_serde::CairoSerde for Session {
         let mut __offset = __offset;
         let expires_at = u64::cairo_deserialize(__felts, __offset)?;
         __offset += u64::cairo_serialized_size(&expires_at);
-        let allowed_policies_root = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += starknet::core::types::Felt::cairo_serialized_size(
-                &allowed_policies_root,
-            );
-        let metadata_hash = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let allowed_policies_root =
+            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&allowed_policies_root);
+        let metadata_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&metadata_hash);
-        let session_key_guid = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += starknet::core::types::Felt::cairo_serialized_size(&session_key_guid);
-        let guardian_key_guid = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
-        __offset
-            += starknet::core::types::Felt::cairo_serialized_size(&guardian_key_guid);
+        let session_key_guid = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&session_key_guid);
+        let guardian_key_guid = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        __offset += starknet::core::types::Felt::cairo_serialized_size(&guardian_key_guid);
         Ok(Session {
             expires_at,
             allowed_policies_root,
@@ -636,13 +545,14 @@ impl cainome::cairo_serde::CairoSerde for SessionRegistered {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.session_hash));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.session_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -650,10 +560,7 @@ impl cainome::cairo_serde::CairoSerde for SessionRegistered {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let session_hash = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let session_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
         Ok(SessionRegistered { session_hash })
     }
@@ -676,13 +583,14 @@ impl cainome::cairo_serde::CairoSerde for SessionRevoked {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.session_hash));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.session_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -690,10 +598,7 @@ impl cainome::cairo_serde::CairoSerde for SessionRevoked {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let session_hash = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let session_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
         Ok(SessionRevoked { session_hash })
     }
@@ -723,34 +628,26 @@ impl cainome::cairo_serde::CairoSerde for SessionToken {
         let mut __size = 0;
         __size += Session::cairo_serialized_size(&__rust.session);
         __size += bool::cairo_serialized_size(&__rust.cache_authorization);
-        __size
-            += Vec::<
-                starknet::core::types::Felt,
-            >::cairo_serialized_size(&__rust.session_authorization);
+        __size += Vec::<starknet::core::types::Felt>::cairo_serialized_size(
+            &__rust.session_authorization,
+        );
         __size += SignerSignature::cairo_serialized_size(&__rust.session_signature);
         __size += SignerSignature::cairo_serialized_size(&__rust.guardian_signature);
-        __size
-            += Vec::<
-                Vec<starknet::core::types::Felt>,
-            >::cairo_serialized_size(&__rust.proofs);
+        __size += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&__rust.proofs);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(Session::cairo_serialize(&__rust.session));
         __out.extend(bool::cairo_serialize(&__rust.cache_authorization));
-        __out
-            .extend(
-                Vec::<
-                    starknet::core::types::Felt,
-                >::cairo_serialize(&__rust.session_authorization),
-            );
+        __out.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            &__rust.session_authorization,
+        ));
         __out.extend(SignerSignature::cairo_serialize(&__rust.session_signature));
         __out.extend(SignerSignature::cairo_serialize(&__rust.guardian_signature));
-        __out
-            .extend(
-                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(&__rust.proofs),
-            );
+        __out.extend(Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(
+            &__rust.proofs,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -762,22 +659,16 @@ impl cainome::cairo_serde::CairoSerde for SessionToken {
         __offset += Session::cairo_serialized_size(&session);
         let cache_authorization = bool::cairo_deserialize(__felts, __offset)?;
         __offset += bool::cairo_serialized_size(&cache_authorization);
-        let session_authorization = Vec::<
-            starknet::core::types::Felt,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += Vec::<
-                starknet::core::types::Felt,
-            >::cairo_serialized_size(&session_authorization);
+        let session_authorization =
+            Vec::<starknet::core::types::Felt>::cairo_deserialize(__felts, __offset)?;
+        __offset +=
+            Vec::<starknet::core::types::Felt>::cairo_serialized_size(&session_authorization);
         let session_signature = SignerSignature::cairo_deserialize(__felts, __offset)?;
         __offset += SignerSignature::cairo_serialized_size(&session_signature);
         let guardian_signature = SignerSignature::cairo_deserialize(__felts, __offset)?;
         __offset += SignerSignature::cairo_serialized_size(&guardian_signature);
-        let proofs = Vec::<
-            Vec<starknet::core::types::Felt>,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&proofs);
+        let proofs = Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(__felts, __offset)?;
+        __offset += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&proofs);
         Ok(SessionToken {
             session,
             cache_authorization,
@@ -869,20 +760,19 @@ impl cainome::cairo_serde::CairoSerde for StarknetSigner {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::NonZero::<
-                starknet::core::types::Felt,
-            >::cairo_serialized_size(&__rust.pubkey);
+        __size +=
+            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialized_size(
+                &__rust.pubkey,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::NonZero::<
-                    starknet::core::types::Felt,
-                >::cairo_serialize(&__rust.pubkey),
-            );
+        __out.extend(
+            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialize(
+                &__rust.pubkey,
+            ),
+        );
         __out
     }
     fn cairo_deserialize(
@@ -890,13 +780,14 @@ impl cainome::cairo_serde::CairoSerde for StarknetSigner {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey = cainome::cairo_serde::NonZero::<
-            starknet::core::types::Felt,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += cainome::cairo_serde::NonZero::<
-                starknet::core::types::Felt,
-            >::cairo_serialized_size(&pubkey);
+        let pubkey =
+            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_deserialize(
+                __felts, __offset,
+            )?;
+        __offset +=
+            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialized_size(
+                &pubkey,
+            );
         Ok(StarknetSigner { pubkey })
     }
 }
@@ -912,21 +803,15 @@ impl cainome::cairo_serde::CairoSerde for TransactionExecuted {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.hash);
-        __size
-            += Vec::<
-                Vec<starknet::core::types::Felt>,
-            >::cairo_serialized_size(&__rust.response);
+        __size += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&__rust.response);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.hash));
-        __out
-            .extend(
-                Vec::<
-                    Vec<starknet::core::types::Felt>,
-                >::cairo_serialize(&__rust.response),
-            );
+        __out.extend(Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(
+            &__rust.response,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -936,15 +821,10 @@ impl cainome::cairo_serde::CairoSerde for TransactionExecuted {
         let mut __offset = __offset;
         let hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-        let response = Vec::<
-            Vec<starknet::core::types::Felt>,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
-        Ok(TransactionExecuted {
-            hash,
-            response,
-        })
+        let response =
+            Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(__felts, __offset)?;
+        __offset += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
+        Ok(TransactionExecuted { hash, response })
     }
 }
 impl TransactionExecuted {
@@ -967,19 +847,17 @@ impl cainome::cairo_serde::CairoSerde for TypedData {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.scope_hash);
-        __size
-            += starknet::core::types::Felt::cairo_serialized_size(
-                &__rust.typed_data_hash,
-            );
+        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.typed_data_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.scope_hash));
-        __out
-            .extend(
-                starknet::core::types::Felt::cairo_serialize(&__rust.typed_data_hash),
-            );
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.scope_hash,
+        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(
+            &__rust.typed_data_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -987,15 +865,9 @@ impl cainome::cairo_serde::CairoSerde for TypedData {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let scope_hash = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let scope_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&scope_hash);
-        let typed_data_hash = starknet::core::types::Felt::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let typed_data_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&typed_data_hash);
         Ok(TypedData {
             scope_hash,
@@ -1013,18 +885,14 @@ impl cainome::cairo_serde::CairoSerde for Upgraded {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size
-            += cainome::cairo_serde::ClassHash::cairo_serialized_size(
-                &__rust.class_hash,
-            );
+        __size += cainome::cairo_serde::ClassHash::cairo_serialized_size(&__rust.class_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out
-            .extend(
-                cainome::cairo_serde::ClassHash::cairo_serialize(&__rust.class_hash),
-            );
+        __out.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
+            &__rust.class_hash,
+        ));
         __out
     }
     fn cairo_deserialize(
@@ -1032,10 +900,7 @@ impl cainome::cairo_serde::CairoSerde for Upgraded {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let class_hash = cainome::cairo_serde::ClassHash::cairo_deserialize(
-            __felts,
-            __offset,
-        )?;
+        let class_hash = cainome::cairo_serde::ClassHash::cairo_deserialize(__felts, __offset)?;
         __offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
         Ok(Upgraded { class_hash })
     }
@@ -1109,31 +974,29 @@ impl cainome::cairo_serde::CairoSerde for WebauthnSigner {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += Vec::<u8>::cairo_serialized_size(&__rust.origin);
-        __size
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&__rust.rp_id_hash);
-        __size
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&__rust.pubkey);
+        __size +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &__rust.rp_id_hash,
+            );
+        __size +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &__rust.pubkey,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(Vec::<u8>::cairo_serialize(&__rust.origin));
-        __out
-            .extend(
-                cainome::cairo_serde::NonZero::<
-                    cainome::cairo_serde::U256,
-                >::cairo_serialize(&__rust.rp_id_hash),
-            );
-        __out
-            .extend(
-                cainome::cairo_serde::NonZero::<
-                    cainome::cairo_serde::U256,
-                >::cairo_serialize(&__rust.pubkey),
-            );
+        __out.extend(
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
+                &__rust.rp_id_hash,
+            ),
+        );
+        __out.extend(
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
+                &__rust.pubkey,
+            ),
+        );
         __out
     }
     fn cairo_deserialize(
@@ -1143,20 +1006,22 @@ impl cainome::cairo_serde::CairoSerde for WebauthnSigner {
         let mut __offset = __offset;
         let origin = Vec::<u8>::cairo_deserialize(__felts, __offset)?;
         __offset += Vec::<u8>::cairo_serialized_size(&origin);
-        let rp_id_hash = cainome::cairo_serde::NonZero::<
-            cainome::cairo_serde::U256,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&rp_id_hash);
-        let pubkey = cainome::cairo_serde::NonZero::<
-            cainome::cairo_serde::U256,
-        >::cairo_deserialize(__felts, __offset)?;
-        __offset
-            += cainome::cairo_serde::NonZero::<
-                cainome::cairo_serde::U256,
-            >::cairo_serialized_size(&pubkey);
+        let rp_id_hash =
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
+                __felts, __offset,
+            )?;
+        __offset +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &rp_id_hash,
+            );
+        let pubkey =
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
+                __felts, __offset,
+            )?;
+        __offset +=
+            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
+                &pubkey,
+            );
         Ok(WebauthnSigner {
             origin,
             rp_id_hash,
@@ -1191,9 +1056,7 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
             ControllerEvent::ReentrancyGuardEvent(val) => {
                 ReentrancyGuardEvent::cairo_serialized_size(val) + 1
             }
-            ControllerEvent::SessionEvent(val) => {
-                SessionEvent::cairo_serialized_size(val) + 1
-            }
+            ControllerEvent::SessionEvent(val) => SessionEvent::cairo_serialized_size(val) + 1,
             ControllerEvent::ExternalOwnersEvent(val) => {
                 ExternalOwnersEvent::cairo_serialized_size(val) + 1
             }
@@ -1203,12 +1066,8 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
             ControllerEvent::DelegateAccountEvents(val) => {
                 DelegateAccountEvent::cairo_serialized_size(val) + 1
             }
-            ControllerEvent::SRC5Events(val) => {
-                Src5ComponentEvent::cairo_serialized_size(val) + 1
-            }
-            ControllerEvent::UpgradeableEvent(val) => {
-                UpgradeEvent::cairo_serialized_size(val) + 1
-            }
+            ControllerEvent::SRC5Events(val) => Src5ComponentEvent::cairo_serialized_size(val) + 1,
+            ControllerEvent::UpgradeableEvent(val) => UpgradeEvent::cairo_serialized_size(val) + 1,
             _ => 0,
         }
     }
@@ -1278,87 +1137,45 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    ControllerEvent::TransactionExecuted(
-                        TransactionExecuted::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    ControllerEvent::MultipleOwnersEvent(
-                        MultipleOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            2usize => {
-                Ok(
-                    ControllerEvent::ReentrancyGuardEvent(
-                        ReentrancyGuardEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            3usize => {
-                Ok(
-                    ControllerEvent::SessionEvent(
-                        SessionEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            4usize => {
-                Ok(
-                    ControllerEvent::ExternalOwnersEvent(
-                        ExternalOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            5usize => {
-                Ok(
-                    ControllerEvent::ExecuteFromOutsideEvents(
-                        OutsideExecutionV3Event::cairo_deserialize(
-                            __felts,
-                            __offset + 1,
-                        )?,
-                    ),
-                )
-            }
-            6usize => {
-                Ok(
-                    ControllerEvent::DelegateAccountEvents(
-                        DelegateAccountEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            7usize => {
-                Ok(
-                    ControllerEvent::SRC5Events(
-                        Src5ComponentEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            8usize => {
-                Ok(
-                    ControllerEvent::UpgradeableEvent(
-                        UpgradeEvent::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(ControllerEvent::TransactionExecuted(
+                TransactionExecuted::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            1usize => Ok(ControllerEvent::MultipleOwnersEvent(
+                MultipleOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            2usize => Ok(ControllerEvent::ReentrancyGuardEvent(
+                ReentrancyGuardEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            3usize => Ok(ControllerEvent::SessionEvent(
+                SessionEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            4usize => Ok(ControllerEvent::ExternalOwnersEvent(
+                ExternalOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            5usize => Ok(ControllerEvent::ExecuteFromOutsideEvents(
+                OutsideExecutionV3Event::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            6usize => Ok(ControllerEvent::DelegateAccountEvents(
+                DelegateAccountEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            7usize => Ok(ControllerEvent::SRC5Events(
+                Src5ComponentEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            8usize => Ok(ControllerEvent::UpgradeableEvent(
+                UpgradeEvent::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "ControllerEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "ControllerEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -1366,50 +1183,39 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("TransactionExecuted")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "TransactionExecuted")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "TransactionExecuted"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.keys,
-                key_offset,
-            ) {
+            let hash = match starknet::core::types::Felt::cairo_deserialize(&event.keys, key_offset)
+            {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "hash",
-                            "TransactionExecuted", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "hash", "TransactionExecuted", e
+                    ));
                 }
             };
             key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-            let response = match Vec::<
-                Vec<starknet::core::types::Felt>,
-            >::cairo_deserialize(&event.data, data_offset) {
+            let response = match Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "response",
-                            "TransactionExecuted", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "response", "TransactionExecuted", e
+                    ));
                 }
             };
-            data_offset
-                += Vec::<
-                    Vec<starknet::core::types::Felt>,
-                >::cairo_serialized_size(&response);
-            return Ok(
-                ControllerEvent::TransactionExecuted(TransactionExecuted {
-                    hash,
-                    response,
-                }),
-            );
+            data_offset +=
+                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
+            return Ok(ControllerEvent::TransactionExecuted(TransactionExecuted {
+                hash,
+                response,
+            }));
         }
         let selector = event.keys[0];
         if selector
@@ -1421,20 +1227,16 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerAdded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerAdded", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(
-                ControllerEvent::MultipleOwnersEvent(
-                    MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
-                ),
-            );
+            return Ok(ControllerEvent::MultipleOwnersEvent(
+                MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1446,20 +1248,16 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerRemoved", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(
-                ControllerEvent::MultipleOwnersEvent(
-                    MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
-                ),
-            );
+            return Ok(ControllerEvent::MultipleOwnersEvent(
+                MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1468,65 +1266,47 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                ControllerEvent::SessionEvent(
-                    SessionEvent::SessionRevoked(SessionRevoked { session_hash }),
-                ),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(ControllerEvent::SessionEvent(SessionEvent::SessionRevoked(
+                SessionRevoked { session_hash },
+            )));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "SessionRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                ControllerEvent::SessionEvent(
-                    SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-                ),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(ControllerEvent::SessionEvent(
+                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1536,32 +1316,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRegistered", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRegistered", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::ExternalOwnersEvent(
-                    ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::ExternalOwnersEvent(
+                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1571,32 +1340,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRemoved", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::ExternalOwnersEvent(
-                    ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::ExternalOwnersEvent(
+                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "DelegateAccountChanged")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1606,25 +1364,16 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "DelegateAccountChanged", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "DelegateAccountChanged", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::DelegateAccountEvents(
-                    DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::DelegateAccountEvents(
+                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1639,23 +1388,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "class_hash",
-                            "Upgraded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "class_hash", "Upgraded", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
-            return Ok(
-                ControllerEvent::UpgradeableEvent(
-                    UpgradeEvent::Upgraded(Upgraded { class_hash }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            return Ok(ControllerEvent::UpgradeableEvent(UpgradeEvent::Upgraded(
+                Upgraded { class_hash },
+            )));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
@@ -1668,50 +1415,39 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("TransactionExecuted")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "TransactionExecuted")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "TransactionExecuted"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.keys,
-                key_offset,
-            ) {
+            let hash = match starknet::core::types::Felt::cairo_deserialize(&event.keys, key_offset)
+            {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "hash",
-                            "TransactionExecuted", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "hash", "TransactionExecuted", e
+                    ));
                 }
             };
             key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-            let response = match Vec::<
-                Vec<starknet::core::types::Felt>,
-            >::cairo_deserialize(&event.data, data_offset) {
+            let response = match Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "response",
-                            "TransactionExecuted", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "response", "TransactionExecuted", e
+                    ));
                 }
             };
-            data_offset
-                += Vec::<
-                    Vec<starknet::core::types::Felt>,
-                >::cairo_serialized_size(&response);
-            return Ok(
-                ControllerEvent::TransactionExecuted(TransactionExecuted {
-                    hash,
-                    response,
-                }),
-            );
+            data_offset +=
+                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
+            return Ok(ControllerEvent::TransactionExecuted(TransactionExecuted {
+                hash,
+                response,
+            }));
         }
         let selector = event.keys[0];
         if selector
@@ -1723,20 +1459,16 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerAdded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerAdded", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(
-                ControllerEvent::MultipleOwnersEvent(
-                    MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
-                ),
-            );
+            return Ok(ControllerEvent::MultipleOwnersEvent(
+                MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1748,20 +1480,16 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerRemoved", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(
-                ControllerEvent::MultipleOwnersEvent(
-                    MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
-                ),
-            );
+            return Ok(ControllerEvent::MultipleOwnersEvent(
+                MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1770,65 +1498,47 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                ControllerEvent::SessionEvent(
-                    SessionEvent::SessionRevoked(SessionRevoked { session_hash }),
-                ),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(ControllerEvent::SessionEvent(SessionEvent::SessionRevoked(
+                SessionRevoked { session_hash },
+            )));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "SessionRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                ControllerEvent::SessionEvent(
-                    SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-                ),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(ControllerEvent::SessionEvent(
+                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1838,32 +1548,21 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRegistered", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRegistered", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::ExternalOwnersEvent(
-                    ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::ExternalOwnersEvent(
+                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1873,32 +1572,21 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRemoved", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::ExternalOwnersEvent(
-                    ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::ExternalOwnersEvent(
+                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "DelegateAccountChanged")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1908,25 +1596,16 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "DelegateAccountChanged", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "DelegateAccountChanged", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ControllerEvent::DelegateAccountEvents(
-                    DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
-                        address,
-                    }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ControllerEvent::DelegateAccountEvents(
+                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged { address }),
+            ));
         }
         let selector = event.keys[0];
         if selector
@@ -1941,23 +1620,21 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "class_hash",
-                            "Upgraded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "class_hash", "Upgraded", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
-            return Ok(
-                ControllerEvent::UpgradeableEvent(
-                    UpgradeEvent::Upgraded(Upgraded { class_hash }),
-                ),
-            );
+            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            return Ok(ControllerEvent::UpgradeableEvent(UpgradeEvent::Upgraded(
+                Upgraded { class_hash },
+            )));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -1994,28 +1671,21 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    DelegateAccountEvent::DelegateAccountChanged(
-                        DelegateAccountChanged::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(DelegateAccountEvent::DelegateAccountChanged(
+                DelegateAccountChanged::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "DelegateAccountEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "DelegateAccountEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2023,9 +1693,7 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "DelegateAccountChanged")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2035,25 +1703,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "DelegateAccountChanged", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "DelegateAccountChanged", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(DelegateAccountEvent::DelegateAccountChanged(
+                DelegateAccountChanged { address },
+            ));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
@@ -2066,9 +1730,7 @@ impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "DelegateAccountChanged")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2078,25 +1740,21 @@ impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "DelegateAccountChanged", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "DelegateAccountChanged", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(DelegateAccountEvent::DelegateAccountChanged(
+                DelegateAccountChanged { address },
+            ));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2143,38 +1801,24 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnersEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    ExternalOwnersEvent::ExternalOwnerRegistered(
-                        ExternalOwnerRegistered::cairo_deserialize(
-                            __felts,
-                            __offset + 1,
-                        )?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    ExternalOwnersEvent::ExternalOwnerRemoved(
-                        ExternalOwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
+                ExternalOwnerRegistered::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            1usize => Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
+                ExternalOwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "ExternalOwnersEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "ExternalOwnersEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2182,9 +1826,7 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2194,30 +1836,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRegistered", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRegistered", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
+                ExternalOwnerRegistered { address },
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2227,25 +1860,21 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRemoved", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
+                ExternalOwnerRemoved { address },
+            ));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
@@ -2258,9 +1887,7 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2270,30 +1897,21 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRegistered", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRegistered", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
+                ExternalOwnerRegistered { address },
+            ));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -2303,25 +1921,21 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "address",
-                            "ExternalOwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "address", "ExternalOwnerRemoved", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
-                    &address,
-                );
-            return Ok(
-                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
-                    address,
-                }),
-            );
+            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+            return Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
+                ExternalOwnerRemoved { address },
+            ));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2335,12 +1949,8 @@ impl cainome::cairo_serde::CairoSerde for MultipleOwnersEvent {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         match __rust {
-            MultipleOwnersEvent::OwnerAdded(val) => {
-                OwnerAdded::cairo_serialized_size(val) + 1
-            }
-            MultipleOwnersEvent::OwnerRemoved(val) => {
-                OwnerRemoved::cairo_serialized_size(val) + 1
-            }
+            MultipleOwnersEvent::OwnerAdded(val) => OwnerAdded::cairo_serialized_size(val) + 1,
+            MultipleOwnersEvent::OwnerRemoved(val) => OwnerRemoved::cairo_serialized_size(val) + 1,
             _ => 0,
         }
     }
@@ -2368,35 +1978,24 @@ impl cainome::cairo_serde::CairoSerde for MultipleOwnersEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    MultipleOwnersEvent::OwnerAdded(
-                        OwnerAdded::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    MultipleOwnersEvent::OwnerRemoved(
-                        OwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(MultipleOwnersEvent::OwnerAdded(
+                OwnerAdded::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            1usize => Ok(MultipleOwnersEvent::OwnerRemoved(
+                OwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "MultipleOwnersEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "MultipleOwnersEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2411,12 +2010,10 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerAdded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerAdded", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
@@ -2432,18 +2029,19 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerRemoved", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
             return Ok(MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
@@ -2463,12 +2061,10 @@ impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerAdded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerAdded", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
@@ -2484,18 +2080,19 @@ impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "owner",
-                            "OwnerRemoved", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "owner", "OwnerRemoved", e
+                    ));
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
             return Ok(MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2522,27 +2119,25 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3Event {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!(
-                            "Index not handle for enum {}", "OutsideExecutionV3Event"
-                        ),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "OutsideExecutionV3Event"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for OutsideExecutionV3Event {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for OutsideExecutionV3Event {
@@ -2552,7 +2147,10 @@ impl TryFrom<&starknet::core::types::Event> for OutsideExecutionV3Event {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2597,25 +2195,18 @@ impl cainome::cairo_serde::CairoSerde for Owner {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(Owner::Signer(Signer::cairo_deserialize(__felts, __offset + 1)?))
-            }
-            1usize => {
-                Ok(
-                    Owner::Account(
-                        cainome::cairo_serde::ContractAddress::cairo_deserialize(
-                            __felts,
-                            __offset + 1,
-                        )?,
-                    ),
-                )
-            }
+            0usize => Ok(Owner::Signer(Signer::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
+            1usize => Ok(Owner::Account(
+                cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "Owner"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "Owner"
+                )));
             }
         }
     }
@@ -2644,25 +2235,25 @@ impl cainome::cairo_serde::CairoSerde for ReentrancyGuardEvent {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "ReentrancyGuardEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "ReentrancyGuardEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ReentrancyGuardEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ReentrancyGuardEvent {
@@ -2672,7 +2263,10 @@ impl TryFrom<&starknet::core::types::Event> for ReentrancyGuardEvent {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2686,9 +2280,7 @@ impl cainome::cairo_serde::CairoSerde for SessionEvent {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         match __rust {
-            SessionEvent::SessionRevoked(val) => {
-                SessionRevoked::cairo_serialized_size(val) + 1
-            }
+            SessionEvent::SessionRevoked(val) => SessionRevoked::cairo_serialized_size(val) + 1,
             SessionEvent::SessionRegistered(val) => {
                 SessionRegistered::cairo_serialized_size(val) + 1
             }
@@ -2719,35 +2311,24 @@ impl cainome::cairo_serde::CairoSerde for SessionEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    SessionEvent::SessionRevoked(
-                        SessionRevoked::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    SessionEvent::SessionRegistered(
-                        SessionRegistered::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(SessionEvent::SessionRevoked(
+                SessionRevoked::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            1usize => Ok(SessionEvent::SessionRegistered(
+                SessionRegistered::cairo_deserialize(__felts, __offset + 1)?,
+            )),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "SessionEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "SessionEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for SessionEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2759,54 +2340,47 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for SessionEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRevoked(SessionRevoked { session_hash }));
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRevoked(SessionRevoked {
+                session_hash,
+            }));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "SessionRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRegistered(SessionRegistered {
+                session_hash,
+            }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for SessionEvent {
@@ -2823,54 +2397,47 @@ impl TryFrom<&starknet::core::types::Event> for SessionEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRevoked(SessionRevoked { session_hash }));
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRevoked(SessionRevoked {
+                session_hash,
+            }));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| {
-                    panic!("Invalid selector for {}", "SessionRegistered")
-                })
+                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
-                &event.data,
-                data_offset,
-            ) {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(
-                        format!(
+            let session_hash =
+                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ),
-                    );
-                }
-            };
-            data_offset
-                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(
-                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-            );
+                        ));
+                    }
+                };
+            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRegistered(SessionRegistered {
+                session_hash,
+            }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2937,47 +2504,31 @@ impl cainome::cairo_serde::CairoSerde for Signer {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    Signer::Starknet(
-                        StarknetSigner::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    Signer::Secp256k1(
-                        Secp256k1Signer::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            2usize => {
-                Ok(
-                    Signer::Secp256r1(
-                        Secp256r1Signer::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            3usize => {
-                Ok(
-                    Signer::Eip191(
-                        Eip191Signer::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            4usize => {
-                Ok(
-                    Signer::Webauthn(
-                        WebauthnSigner::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(Signer::Starknet(StarknetSigner::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
+            1usize => Ok(Signer::Secp256k1(Secp256k1Signer::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
+            2usize => Ok(Signer::Secp256r1(Secp256r1Signer::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
+            3usize => Ok(Signer::Eip191(Eip191Signer::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
+            4usize => Ok(Signer::Webauthn(WebauthnSigner::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "Signer"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "Signer"
+                )));
             }
         }
     }
@@ -3056,62 +2607,32 @@ impl cainome::cairo_serde::CairoSerde for SignerSignature {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    SignerSignature::Starknet(
-                        <(
-                            StarknetSigner,
-                            StarknetSignature,
-                        )>::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            1usize => {
-                Ok(
-                    SignerSignature::Secp256k1(
-                        <(
-                            Secp256k1Signer,
-                            Signature,
-                        )>::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            2usize => {
-                Ok(
-                    SignerSignature::Secp256r1(
-                        <(
-                            Secp256r1Signer,
-                            Signature,
-                        )>::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            3usize => {
-                Ok(
-                    SignerSignature::Eip191(
-                        <(
-                            Eip191Signer,
-                            Signature,
-                        )>::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
-            4usize => {
-                Ok(
-                    SignerSignature::Webauthn(
-                        <(
-                            WebauthnSigner,
-                            WebauthnSignature,
-                        )>::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(SignerSignature::Starknet(<(
+                StarknetSigner,
+                StarknetSignature,
+            )>::cairo_deserialize(
+                __felts, __offset + 1
+            )?)),
+            1usize => Ok(SignerSignature::Secp256k1(
+                <(Secp256k1Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            2usize => Ok(SignerSignature::Secp256r1(
+                <(Secp256r1Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            3usize => Ok(SignerSignature::Eip191(
+                <(Eip191Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
+            )),
+            4usize => Ok(SignerSignature::Webauthn(<(
+                WebauthnSigner,
+                WebauthnSignature,
+            )>::cairo_deserialize(
+                __felts, __offset + 1
+            )?)),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "SignerSignature"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "SignerSignature"
+                )));
             }
         }
     }
@@ -3140,25 +2661,25 @@ impl cainome::cairo_serde::CairoSerde for Src5ComponentEvent {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "Src5ComponentEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "Src5ComponentEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for Src5ComponentEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for Src5ComponentEvent {
@@ -3168,7 +2689,10 @@ impl TryFrom<&starknet::core::types::Event> for Src5ComponentEvent {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -3203,28 +2727,22 @@ impl cainome::cairo_serde::CairoSerde for UpgradeEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => {
-                Ok(
-                    UpgradeEvent::Upgraded(
-                        Upgraded::cairo_deserialize(__felts, __offset + 1)?,
-                    ),
-                )
-            }
+            0usize => Ok(UpgradeEvent::Upgraded(Upgraded::cairo_deserialize(
+                __felts,
+                __offset + 1,
+            )?)),
             _ => {
-                return Err(
-                    cainome::cairo_serde::Error::Deserialize(
-                        format!("Index not handle for enum {}", "UpgradeEvent"),
-                    ),
-                );
+                return Err(cainome::cairo_serde::Error::Deserialize(format!(
+                    "Index not handle for enum {}",
+                    "UpgradeEvent"
+                )));
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for UpgradeEvent {
     type Error = String;
-    fn try_from(
-        event: &starknet::core::types::EmittedEvent,
-    ) -> Result<Self, Self::Error> {
+    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -3242,19 +2760,19 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for UpgradeEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "class_hash",
-                            "Upgraded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "class_hash", "Upgraded", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
             return Ok(UpgradeEvent::Upgraded(Upgraded { class_hash }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for UpgradeEvent {
@@ -3277,19 +2795,19 @@ impl TryFrom<&starknet::core::types::Event> for UpgradeEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(
-                        format!(
-                            "Could not deserialize field {} for {}: {:?}", "class_hash",
-                            "Upgraded", e
-                        ),
-                    );
+                    return Err(format!(
+                        "Could not deserialize field {} for {}: {:?}",
+                        "class_hash", "Upgraded", e
+                    ));
                 }
             };
-            data_offset
-                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
             return Ok(UpgradeEvent::Upgraded(Upgraded { class_hash }));
         }
-        Err(format!("Could not match any event from keys {:?}", event.keys))
+        Err(format!(
+            "Could not match any event from keys {:?}",
+            event.keys
+        ))
     }
 }
 impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
@@ -3304,9 +2822,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         __calldata.extend(SignerSignature::cairo_serialize(signer_signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!(
-                "assert_valid_owner_signature"
-            ),
+            entry_point_selector: starknet::macros::selector!("assert_valid_owner_signature"),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -3315,10 +2831,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn delegate_account(
         &self,
-    ) -> cainome::cairo_serde::call::FCall<
-        A::Provider,
-        cainome::cairo_serde::ContractAddress,
-    > {
+    ) -> cainome::cairo_serde::call::FCall<A::Provider, cainome::cairo_serde::ContractAddress> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         let __call = starknet::core::types::FunctionCall {
@@ -3372,12 +2885,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> cainome::cairo_serde::call::FCall<A::Provider, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_external_owner"),
@@ -3411,7 +2921,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(session_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            guid_or_address,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_session_registered"),
@@ -3448,9 +2960,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         __calldata.extend(SessionToken::cairo_serialize(token));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!(
-                "is_session_signature_valid"
-            ),
+            entry_point_selector: starknet::macros::selector!("is_session_signature_valid"),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -3463,7 +2973,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> cainome::cairo_serde::call::FCall<A::Provider, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(nonce));
+        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
+            nonce,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!(
@@ -3483,8 +2995,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(hash));
-        __calldata
-            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
+        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            signature,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_valid_signature"),
@@ -3535,10 +3048,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     }
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::too_many_arguments)]
-    pub fn __validate___getcall(
-        &self,
-        calls: &Vec<Call>,
-    ) -> starknet::core::types::Call {
+    pub fn __validate___getcall(&self, calls: &Vec<Call>) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Vec::<Call>::cairo_serialize(calls));
@@ -3604,8 +3114,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(class_hash));
-        __calldata
-            .extend(starknet::core::types::Felt::cairo_serialize(contract_address_salt));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            contract_address_salt,
+        ));
         __calldata.extend(Owner::cairo_serialize(owner));
         __calldata.extend(Option::<Signer>::cairo_serialize(guardian));
         starknet::core::types::Call {
@@ -3626,8 +3137,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(class_hash));
-        __calldata
-            .extend(starknet::core::types::Felt::cairo_serialize(contract_address_salt));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            contract_address_salt,
+        ));
         __calldata.extend(Owner::cairo_serialize(owner));
         __calldata.extend(Option::<Signer>::cairo_serialize(guardian));
         let __call = starknet::core::types::Call {
@@ -3682,8 +3194,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(OutsideExecutionV3::cairo_serialize(outside_execution));
-        __calldata
-            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
+        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            signature,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("execute_from_outside_v3"),
@@ -3700,8 +3213,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(OutsideExecutionV3::cairo_serialize(outside_execution));
-        __calldata
-            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
+        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            signature,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("execute_from_outside_v3"),
@@ -3717,12 +3231,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_external_owner"),
@@ -3737,12 +3248,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_external_owner"),
@@ -3760,7 +3268,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Session::cairo_serialize(session));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            guid_or_address,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_session"),
@@ -3777,7 +3287,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Session::cairo_serialize(session));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            guid_or_address,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_session"),
@@ -3793,12 +3305,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("remove_external_owner"),
@@ -3813,12 +3322,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("remove_external_owner"),
@@ -3890,10 +3396,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(delegate_address),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            delegate_address,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("set_delegate_account"),
@@ -3908,10 +3413,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(delegate_address),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            delegate_address,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("set_delegate_account"),
@@ -3927,8 +3431,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(cainome::cairo_serde::ClassHash::cairo_serialize(new_class_hash));
+        __calldata.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
+            new_class_hash,
+        ));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("upgrade"),
@@ -3943,8 +3448,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(cainome::cairo_serde::ClassHash::cairo_serialize(new_class_hash));
+        __calldata.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
+            new_class_hash,
+        ));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("upgrade"),
@@ -3965,9 +3471,7 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         __calldata.extend(SignerSignature::cairo_serialize(signer_signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!(
-                "assert_valid_owner_signature"
-            ),
+            entry_point_selector: starknet::macros::selector!("assert_valid_owner_signature"),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -4030,12 +3534,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
     ) -> cainome::cairo_serde::call::FCall<P, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata
-            .extend(
-                cainome::cairo_serde::ContractAddress::cairo_serialize(
-                    external_owner_address,
-                ),
-            );
+        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
+            external_owner_address,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_external_owner"),
@@ -4069,7 +3570,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(session_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
+            guid_or_address,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_session_registered"),
@@ -4106,9 +3609,7 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         __calldata.extend(SessionToken::cairo_serialize(token));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!(
-                "is_session_signature_valid"
-            ),
+            entry_point_selector: starknet::macros::selector!("is_session_signature_valid"),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -4121,7 +3622,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
     ) -> cainome::cairo_serde::call::FCall<P, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(nonce));
+        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
+            nonce,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!(
@@ -4141,8 +3644,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(hash));
-        __calldata
-            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
+        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
+            signature,
+        ));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_valid_signature"),

--- a/account_sdk/src/abigen/controller.rs
+++ b/account_sdk/src/abigen/controller.rs
@@ -75,22 +75,23 @@ impl cainome::cairo_serde::CairoSerde for Call {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.to);
+        __size
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.to);
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.selector);
-        __size += Vec::<starknet::core::types::Felt>::cairo_serialized_size(&__rust.calldata);
+        __size
+            += Vec::<
+                starknet::core::types::Felt,
+            >::cairo_serialized_size(&__rust.calldata);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            &__rust.to,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.selector,
-        ));
-        __out.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            &__rust.calldata,
-        ));
+        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.to));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.selector));
+        __out
+            .extend(
+                Vec::<starknet::core::types::Felt>::cairo_serialize(&__rust.calldata),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -98,17 +99,21 @@ impl cainome::cairo_serde::CairoSerde for Call {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let to = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
+        let to = cainome::cairo_serde::ContractAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&to);
-        let selector = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let selector = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&selector);
-        let calldata = Vec::<starknet::core::types::Felt>::cairo_deserialize(__felts, __offset)?;
+        let calldata = Vec::<
+            starknet::core::types::Felt,
+        >::cairo_deserialize(__felts, __offset)?;
         __offset += Vec::<starknet::core::types::Felt>::cairo_serialized_size(&calldata);
-        Ok(Call {
-            to,
-            selector,
-            calldata,
-        })
+        Ok(Call { to, selector, calldata })
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -121,14 +126,18 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountChanged {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
+        __size
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                &__rust.address,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            &__rust.address,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -136,8 +145,12 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountChanged {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(DelegateAccountChanged { address })
     }
 }
@@ -159,14 +172,18 @@ impl cainome::cairo_serde::CairoSerde for Eip191Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::EthAddress::cairo_serialized_size(&__rust.eth_address);
+        __size
+            += cainome::cairo_serde::EthAddress::cairo_serialized_size(
+                &__rust.eth_address,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::EthAddress::cairo_serialize(
-            &__rust.eth_address,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::EthAddress::cairo_serialize(&__rust.eth_address),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -174,8 +191,12 @@ impl cainome::cairo_serde::CairoSerde for Eip191Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let eth_address = cainome::cairo_serde::EthAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::EthAddress::cairo_serialized_size(&eth_address);
+        let eth_address = cainome::cairo_serde::EthAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::EthAddress::cairo_serialized_size(&eth_address);
         Ok(Eip191Signer { eth_address })
     }
 }
@@ -189,14 +210,18 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRegistered {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
+        __size
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                &__rust.address,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            &__rust.address,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -204,8 +229,12 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRegistered {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(ExternalOwnerRegistered { address })
     }
 }
@@ -227,14 +256,18 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRemoved {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.address);
+        __size
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                &__rust.address,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            &__rust.address,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.address),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -242,8 +275,12 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnerRemoved {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
+        let address = cainome::cairo_serde::ContractAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
         Ok(ExternalOwnerRemoved { address })
     }
 }
@@ -281,8 +318,15 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&__rust.caller);
-        __size += <(starknet::core::types::Felt, u128)>::cairo_serialized_size(&__rust.nonce);
+        __size
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                &__rust.caller,
+            );
+        __size
+            += <(
+                starknet::core::types::Felt,
+                u128,
+            )>::cairo_serialized_size(&__rust.nonce);
         __size += u64::cairo_serialized_size(&__rust.execute_after);
         __size += u64::cairo_serialized_size(&__rust.execute_before);
         __size += Vec::<Call>::cairo_serialized_size(&__rust.calls);
@@ -290,12 +334,14 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            &__rust.caller,
-        ));
-        __out.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
-            &__rust.nonce,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(&__rust.caller),
+            );
+        __out
+            .extend(
+                <(starknet::core::types::Felt, u128)>::cairo_serialize(&__rust.nonce),
+            );
         __out.extend(u64::cairo_serialize(&__rust.execute_after));
         __out.extend(u64::cairo_serialize(&__rust.execute_before));
         __out.extend(Vec::<Call>::cairo_serialize(&__rust.calls));
@@ -306,9 +352,16 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3 {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let caller = cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&caller);
-        let nonce = <(starknet::core::types::Felt, u128)>::cairo_deserialize(__felts, __offset)?;
+        let caller = cainome::cairo_serde::ContractAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&caller);
+        let nonce = <(
+            starknet::core::types::Felt,
+            u128,
+        )>::cairo_deserialize(__felts, __offset)?;
         __offset += <(starknet::core::types::Felt, u128)>::cairo_serialized_size(&nonce);
         let execute_after = u64::cairo_deserialize(__felts, __offset)?;
         __offset += u64::cairo_serialized_size(&execute_after);
@@ -407,14 +460,18 @@ impl cainome::cairo_serde::CairoSerde for Secp256k1Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::EthAddress::cairo_serialized_size(&__rust.pubkey_hash);
+        __size
+            += cainome::cairo_serde::EthAddress::cairo_serialized_size(
+                &__rust.pubkey_hash,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::EthAddress::cairo_serialize(
-            &__rust.pubkey_hash,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::EthAddress::cairo_serialize(&__rust.pubkey_hash),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -422,8 +479,12 @@ impl cainome::cairo_serde::CairoSerde for Secp256k1Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey_hash = cainome::cairo_serde::EthAddress::cairo_deserialize(__felts, __offset)?;
-        __offset += cainome::cairo_serde::EthAddress::cairo_serialized_size(&pubkey_hash);
+        let pubkey_hash = cainome::cairo_serde::EthAddress::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += cainome::cairo_serde::EthAddress::cairo_serialized_size(&pubkey_hash);
         Ok(Secp256k1Signer { pubkey_hash })
     }
 }
@@ -437,19 +498,20 @@ impl cainome::cairo_serde::CairoSerde for Secp256r1Signer {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &__rust.pubkey,
-            );
+        __size
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&__rust.pubkey);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
-                &__rust.pubkey,
-            ),
-        );
+        __out
+            .extend(
+                cainome::cairo_serde::NonZero::<
+                    cainome::cairo_serde::U256,
+                >::cairo_serialize(&__rust.pubkey),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -457,14 +519,13 @@ impl cainome::cairo_serde::CairoSerde for Secp256r1Signer {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey =
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
-                __felts, __offset,
-            )?;
-        __offset +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &pubkey,
-            );
+        let pubkey = cainome::cairo_serde::NonZero::<
+            cainome::cairo_serde::U256,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&pubkey);
         Ok(Secp256r1Signer { pubkey })
     }
 }
@@ -487,27 +548,41 @@ impl cainome::cairo_serde::CairoSerde for Session {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += u64::cairo_serialized_size(&__rust.expires_at);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.allowed_policies_root);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.metadata_hash);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_key_guid);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.guardian_key_guid);
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(
+                &__rust.allowed_policies_root,
+            );
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(&__rust.metadata_hash);
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(
+                &__rust.session_key_guid,
+            );
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(
+                &__rust.guardian_key_guid,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(u64::cairo_serialize(&__rust.expires_at));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.allowed_policies_root,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.metadata_hash,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.session_key_guid,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.guardian_key_guid,
-        ));
+        __out
+            .extend(
+                starknet::core::types::Felt::cairo_serialize(
+                    &__rust.allowed_policies_root,
+                ),
+            );
+        __out
+            .extend(starknet::core::types::Felt::cairo_serialize(&__rust.metadata_hash));
+        __out
+            .extend(
+                starknet::core::types::Felt::cairo_serialize(&__rust.session_key_guid),
+            );
+        __out
+            .extend(
+                starknet::core::types::Felt::cairo_serialize(&__rust.guardian_key_guid),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -517,15 +592,31 @@ impl cainome::cairo_serde::CairoSerde for Session {
         let mut __offset = __offset;
         let expires_at = u64::cairo_deserialize(__felts, __offset)?;
         __offset += u64::cairo_serialized_size(&expires_at);
-        let allowed_policies_root =
-            starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&allowed_policies_root);
-        let metadata_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let allowed_policies_root = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += starknet::core::types::Felt::cairo_serialized_size(
+                &allowed_policies_root,
+            );
+        let metadata_hash = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&metadata_hash);
-        let session_key_guid = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&session_key_guid);
-        let guardian_key_guid = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
-        __offset += starknet::core::types::Felt::cairo_serialized_size(&guardian_key_guid);
+        let session_key_guid = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += starknet::core::types::Felt::cairo_serialized_size(&session_key_guid);
+        let guardian_key_guid = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
+        __offset
+            += starknet::core::types::Felt::cairo_serialized_size(&guardian_key_guid);
         Ok(Session {
             expires_at,
             allowed_policies_root,
@@ -545,14 +636,13 @@ impl cainome::cairo_serde::CairoSerde for SessionRegistered {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.session_hash,
-        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.session_hash));
         __out
     }
     fn cairo_deserialize(
@@ -560,7 +650,10 @@ impl cainome::cairo_serde::CairoSerde for SessionRegistered {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let session_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let session_hash = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
         Ok(SessionRegistered { session_hash })
     }
@@ -583,14 +676,13 @@ impl cainome::cairo_serde::CairoSerde for SessionRevoked {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(&__rust.session_hash);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.session_hash,
-        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.session_hash));
         __out
     }
     fn cairo_deserialize(
@@ -598,7 +690,10 @@ impl cainome::cairo_serde::CairoSerde for SessionRevoked {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let session_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let session_hash = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
         Ok(SessionRevoked { session_hash })
     }
@@ -628,26 +723,34 @@ impl cainome::cairo_serde::CairoSerde for SessionToken {
         let mut __size = 0;
         __size += Session::cairo_serialized_size(&__rust.session);
         __size += bool::cairo_serialized_size(&__rust.cache_authorization);
-        __size += Vec::<starknet::core::types::Felt>::cairo_serialized_size(
-            &__rust.session_authorization,
-        );
+        __size
+            += Vec::<
+                starknet::core::types::Felt,
+            >::cairo_serialized_size(&__rust.session_authorization);
         __size += SignerSignature::cairo_serialized_size(&__rust.session_signature);
         __size += SignerSignature::cairo_serialized_size(&__rust.guardian_signature);
-        __size += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&__rust.proofs);
+        __size
+            += Vec::<
+                Vec<starknet::core::types::Felt>,
+            >::cairo_serialized_size(&__rust.proofs);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(Session::cairo_serialize(&__rust.session));
         __out.extend(bool::cairo_serialize(&__rust.cache_authorization));
-        __out.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            &__rust.session_authorization,
-        ));
+        __out
+            .extend(
+                Vec::<
+                    starknet::core::types::Felt,
+                >::cairo_serialize(&__rust.session_authorization),
+            );
         __out.extend(SignerSignature::cairo_serialize(&__rust.session_signature));
         __out.extend(SignerSignature::cairo_serialize(&__rust.guardian_signature));
-        __out.extend(Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(
-            &__rust.proofs,
-        ));
+        __out
+            .extend(
+                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(&__rust.proofs),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -659,16 +762,22 @@ impl cainome::cairo_serde::CairoSerde for SessionToken {
         __offset += Session::cairo_serialized_size(&session);
         let cache_authorization = bool::cairo_deserialize(__felts, __offset)?;
         __offset += bool::cairo_serialized_size(&cache_authorization);
-        let session_authorization =
-            Vec::<starknet::core::types::Felt>::cairo_deserialize(__felts, __offset)?;
-        __offset +=
-            Vec::<starknet::core::types::Felt>::cairo_serialized_size(&session_authorization);
+        let session_authorization = Vec::<
+            starknet::core::types::Felt,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += Vec::<
+                starknet::core::types::Felt,
+            >::cairo_serialized_size(&session_authorization);
         let session_signature = SignerSignature::cairo_deserialize(__felts, __offset)?;
         __offset += SignerSignature::cairo_serialized_size(&session_signature);
         let guardian_signature = SignerSignature::cairo_deserialize(__felts, __offset)?;
         __offset += SignerSignature::cairo_serialized_size(&guardian_signature);
-        let proofs = Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(__felts, __offset)?;
-        __offset += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&proofs);
+        let proofs = Vec::<
+            Vec<starknet::core::types::Felt>,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&proofs);
         Ok(SessionToken {
             session,
             cache_authorization,
@@ -760,19 +869,20 @@ impl cainome::cairo_serde::CairoSerde for StarknetSigner {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size +=
-            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialized_size(
-                &__rust.pubkey,
-            );
+        __size
+            += cainome::cairo_serde::NonZero::<
+                starknet::core::types::Felt,
+            >::cairo_serialized_size(&__rust.pubkey);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(
-            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialize(
-                &__rust.pubkey,
-            ),
-        );
+        __out
+            .extend(
+                cainome::cairo_serde::NonZero::<
+                    starknet::core::types::Felt,
+                >::cairo_serialize(&__rust.pubkey),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -780,14 +890,13 @@ impl cainome::cairo_serde::CairoSerde for StarknetSigner {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let pubkey =
-            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_deserialize(
-                __felts, __offset,
-            )?;
-        __offset +=
-            cainome::cairo_serde::NonZero::<starknet::core::types::Felt>::cairo_serialized_size(
-                &pubkey,
-            );
+        let pubkey = cainome::cairo_serde::NonZero::<
+            starknet::core::types::Felt,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += cainome::cairo_serde::NonZero::<
+                starknet::core::types::Felt,
+            >::cairo_serialized_size(&pubkey);
         Ok(StarknetSigner { pubkey })
     }
 }
@@ -803,15 +912,21 @@ impl cainome::cairo_serde::CairoSerde for TransactionExecuted {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.hash);
-        __size += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&__rust.response);
+        __size
+            += Vec::<
+                Vec<starknet::core::types::Felt>,
+            >::cairo_serialized_size(&__rust.response);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.hash));
-        __out.extend(Vec::<Vec<starknet::core::types::Felt>>::cairo_serialize(
-            &__rust.response,
-        ));
+        __out
+            .extend(
+                Vec::<
+                    Vec<starknet::core::types::Felt>,
+                >::cairo_serialize(&__rust.response),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -821,10 +936,15 @@ impl cainome::cairo_serde::CairoSerde for TransactionExecuted {
         let mut __offset = __offset;
         let hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-        let response =
-            Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(__felts, __offset)?;
-        __offset += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
-        Ok(TransactionExecuted { hash, response })
+        let response = Vec::<
+            Vec<starknet::core::types::Felt>,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
+        Ok(TransactionExecuted {
+            hash,
+            response,
+        })
     }
 }
 impl TransactionExecuted {
@@ -847,17 +967,19 @@ impl cainome::cairo_serde::CairoSerde for TypedData {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.scope_hash);
-        __size += starknet::core::types::Felt::cairo_serialized_size(&__rust.typed_data_hash);
+        __size
+            += starknet::core::types::Felt::cairo_serialized_size(
+                &__rust.typed_data_hash,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.scope_hash,
-        ));
-        __out.extend(starknet::core::types::Felt::cairo_serialize(
-            &__rust.typed_data_hash,
-        ));
+        __out.extend(starknet::core::types::Felt::cairo_serialize(&__rust.scope_hash));
+        __out
+            .extend(
+                starknet::core::types::Felt::cairo_serialize(&__rust.typed_data_hash),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -865,9 +987,15 @@ impl cainome::cairo_serde::CairoSerde for TypedData {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let scope_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let scope_hash = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&scope_hash);
-        let typed_data_hash = starknet::core::types::Felt::cairo_deserialize(__felts, __offset)?;
+        let typed_data_hash = starknet::core::types::Felt::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += starknet::core::types::Felt::cairo_serialized_size(&typed_data_hash);
         Ok(TypedData {
             scope_hash,
@@ -885,14 +1013,18 @@ impl cainome::cairo_serde::CairoSerde for Upgraded {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
-        __size += cainome::cairo_serde::ClassHash::cairo_serialized_size(&__rust.class_hash);
+        __size
+            += cainome::cairo_serde::ClassHash::cairo_serialized_size(
+                &__rust.class_hash,
+            );
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
-        __out.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
-            &__rust.class_hash,
-        ));
+        __out
+            .extend(
+                cainome::cairo_serde::ClassHash::cairo_serialize(&__rust.class_hash),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -900,7 +1032,10 @@ impl cainome::cairo_serde::CairoSerde for Upgraded {
         __offset: usize,
     ) -> cainome::cairo_serde::Result<Self::RustType> {
         let mut __offset = __offset;
-        let class_hash = cainome::cairo_serde::ClassHash::cairo_deserialize(__felts, __offset)?;
+        let class_hash = cainome::cairo_serde::ClassHash::cairo_deserialize(
+            __felts,
+            __offset,
+        )?;
         __offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
         Ok(Upgraded { class_hash })
     }
@@ -974,29 +1109,31 @@ impl cainome::cairo_serde::CairoSerde for WebauthnSigner {
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         let mut __size = 0;
         __size += Vec::<u8>::cairo_serialized_size(&__rust.origin);
-        __size +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &__rust.rp_id_hash,
-            );
-        __size +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &__rust.pubkey,
-            );
+        __size
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&__rust.rp_id_hash);
+        __size
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&__rust.pubkey);
         __size
     }
     fn cairo_serialize(__rust: &Self::RustType) -> Vec<starknet::core::types::Felt> {
         let mut __out: Vec<starknet::core::types::Felt> = vec![];
         __out.extend(Vec::<u8>::cairo_serialize(&__rust.origin));
-        __out.extend(
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
-                &__rust.rp_id_hash,
-            ),
-        );
-        __out.extend(
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialize(
-                &__rust.pubkey,
-            ),
-        );
+        __out
+            .extend(
+                cainome::cairo_serde::NonZero::<
+                    cainome::cairo_serde::U256,
+                >::cairo_serialize(&__rust.rp_id_hash),
+            );
+        __out
+            .extend(
+                cainome::cairo_serde::NonZero::<
+                    cainome::cairo_serde::U256,
+                >::cairo_serialize(&__rust.pubkey),
+            );
         __out
     }
     fn cairo_deserialize(
@@ -1006,22 +1143,20 @@ impl cainome::cairo_serde::CairoSerde for WebauthnSigner {
         let mut __offset = __offset;
         let origin = Vec::<u8>::cairo_deserialize(__felts, __offset)?;
         __offset += Vec::<u8>::cairo_serialized_size(&origin);
-        let rp_id_hash =
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
-                __felts, __offset,
-            )?;
-        __offset +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &rp_id_hash,
-            );
-        let pubkey =
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_deserialize(
-                __felts, __offset,
-            )?;
-        __offset +=
-            cainome::cairo_serde::NonZero::<cainome::cairo_serde::U256>::cairo_serialized_size(
-                &pubkey,
-            );
+        let rp_id_hash = cainome::cairo_serde::NonZero::<
+            cainome::cairo_serde::U256,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&rp_id_hash);
+        let pubkey = cainome::cairo_serde::NonZero::<
+            cainome::cairo_serde::U256,
+        >::cairo_deserialize(__felts, __offset)?;
+        __offset
+            += cainome::cairo_serde::NonZero::<
+                cainome::cairo_serde::U256,
+            >::cairo_serialized_size(&pubkey);
         Ok(WebauthnSigner {
             origin,
             rp_id_hash,
@@ -1056,7 +1191,9 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
             ControllerEvent::ReentrancyGuardEvent(val) => {
                 ReentrancyGuardEvent::cairo_serialized_size(val) + 1
             }
-            ControllerEvent::SessionEvent(val) => SessionEvent::cairo_serialized_size(val) + 1,
+            ControllerEvent::SessionEvent(val) => {
+                SessionEvent::cairo_serialized_size(val) + 1
+            }
             ControllerEvent::ExternalOwnersEvent(val) => {
                 ExternalOwnersEvent::cairo_serialized_size(val) + 1
             }
@@ -1066,8 +1203,12 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
             ControllerEvent::DelegateAccountEvents(val) => {
                 DelegateAccountEvent::cairo_serialized_size(val) + 1
             }
-            ControllerEvent::SRC5Events(val) => Src5ComponentEvent::cairo_serialized_size(val) + 1,
-            ControllerEvent::UpgradeableEvent(val) => UpgradeEvent::cairo_serialized_size(val) + 1,
+            ControllerEvent::SRC5Events(val) => {
+                Src5ComponentEvent::cairo_serialized_size(val) + 1
+            }
+            ControllerEvent::UpgradeableEvent(val) => {
+                UpgradeEvent::cairo_serialized_size(val) + 1
+            }
             _ => 0,
         }
     }
@@ -1137,45 +1278,87 @@ impl cainome::cairo_serde::CairoSerde for ControllerEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(ControllerEvent::TransactionExecuted(
-                TransactionExecuted::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            1usize => Ok(ControllerEvent::MultipleOwnersEvent(
-                MultipleOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            2usize => Ok(ControllerEvent::ReentrancyGuardEvent(
-                ReentrancyGuardEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            3usize => Ok(ControllerEvent::SessionEvent(
-                SessionEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            4usize => Ok(ControllerEvent::ExternalOwnersEvent(
-                ExternalOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            5usize => Ok(ControllerEvent::ExecuteFromOutsideEvents(
-                OutsideExecutionV3Event::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            6usize => Ok(ControllerEvent::DelegateAccountEvents(
-                DelegateAccountEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            7usize => Ok(ControllerEvent::SRC5Events(
-                Src5ComponentEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            8usize => Ok(ControllerEvent::UpgradeableEvent(
-                UpgradeEvent::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(
+                    ControllerEvent::TransactionExecuted(
+                        TransactionExecuted::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    ControllerEvent::MultipleOwnersEvent(
+                        MultipleOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            2usize => {
+                Ok(
+                    ControllerEvent::ReentrancyGuardEvent(
+                        ReentrancyGuardEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            3usize => {
+                Ok(
+                    ControllerEvent::SessionEvent(
+                        SessionEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            4usize => {
+                Ok(
+                    ControllerEvent::ExternalOwnersEvent(
+                        ExternalOwnersEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            5usize => {
+                Ok(
+                    ControllerEvent::ExecuteFromOutsideEvents(
+                        OutsideExecutionV3Event::cairo_deserialize(
+                            __felts,
+                            __offset + 1,
+                        )?,
+                    ),
+                )
+            }
+            6usize => {
+                Ok(
+                    ControllerEvent::DelegateAccountEvents(
+                        DelegateAccountEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            7usize => {
+                Ok(
+                    ControllerEvent::SRC5Events(
+                        Src5ComponentEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            8usize => {
+                Ok(
+                    ControllerEvent::UpgradeableEvent(
+                        UpgradeEvent::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "ControllerEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "ControllerEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -1183,39 +1366,50 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("TransactionExecuted")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "TransactionExecuted"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "TransactionExecuted")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let hash = match starknet::core::types::Felt::cairo_deserialize(&event.keys, key_offset)
-            {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "hash", "TransactionExecuted", e
-                    ));
-                }
-            };
-            key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-            let response = match Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(
-                &event.data,
-                data_offset,
+            let hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.keys,
+                key_offset,
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "response", "TransactionExecuted", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "hash",
+                            "TransactionExecuted", e
+                        ),
+                    );
                 }
             };
-            data_offset +=
-                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
-            return Ok(ControllerEvent::TransactionExecuted(TransactionExecuted {
-                hash,
-                response,
-            }));
+            key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
+            let response = match Vec::<
+                Vec<starknet::core::types::Felt>,
+            >::cairo_deserialize(&event.data, data_offset) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "response",
+                            "TransactionExecuted", e
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += Vec::<
+                    Vec<starknet::core::types::Felt>,
+                >::cairo_serialized_size(&response);
+            return Ok(
+                ControllerEvent::TransactionExecuted(TransactionExecuted {
+                    hash,
+                    response,
+                }),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1227,16 +1421,20 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerAdded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerAdded", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(ControllerEvent::MultipleOwnersEvent(
-                MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
-            ));
+            return Ok(
+                ControllerEvent::MultipleOwnersEvent(
+                    MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1248,16 +1446,20 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerRemoved", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(ControllerEvent::MultipleOwnersEvent(
-                MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
-            ));
+            return Ok(
+                ControllerEvent::MultipleOwnersEvent(
+                    MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1266,47 +1468,65 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(ControllerEvent::SessionEvent(SessionEvent::SessionRevoked(
-                SessionRevoked { session_hash },
-            )));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                ControllerEvent::SessionEvent(
+                    SessionEvent::SessionRevoked(SessionRevoked { session_hash }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "SessionRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(ControllerEvent::SessionEvent(
-                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-            ));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                ControllerEvent::SessionEvent(
+                    SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1316,21 +1536,32 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRegistered", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRegistered", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::ExternalOwnersEvent(
-                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::ExternalOwnersEvent(
+                    ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1340,21 +1571,32 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRemoved", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::ExternalOwnersEvent(
-                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::ExternalOwnersEvent(
+                    ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "DelegateAccountChanged")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1364,16 +1606,25 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "DelegateAccountChanged", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "DelegateAccountChanged", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::DelegateAccountEvents(
-                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::DelegateAccountEvents(
+                    DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1388,21 +1639,23 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "class_hash", "Upgraded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "class_hash",
+                            "Upgraded", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
-            return Ok(ControllerEvent::UpgradeableEvent(UpgradeEvent::Upgraded(
-                Upgraded { class_hash },
-            )));
+            data_offset
+                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            return Ok(
+                ControllerEvent::UpgradeableEvent(
+                    UpgradeEvent::Upgraded(Upgraded { class_hash }),
+                ),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
@@ -1415,39 +1668,50 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("TransactionExecuted")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "TransactionExecuted"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "TransactionExecuted")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let hash = match starknet::core::types::Felt::cairo_deserialize(&event.keys, key_offset)
-            {
-                Ok(v) => v,
-                Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "hash", "TransactionExecuted", e
-                    ));
-                }
-            };
-            key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
-            let response = match Vec::<Vec<starknet::core::types::Felt>>::cairo_deserialize(
-                &event.data,
-                data_offset,
+            let hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.keys,
+                key_offset,
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "response", "TransactionExecuted", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "hash",
+                            "TransactionExecuted", e
+                        ),
+                    );
                 }
             };
-            data_offset +=
-                Vec::<Vec<starknet::core::types::Felt>>::cairo_serialized_size(&response);
-            return Ok(ControllerEvent::TransactionExecuted(TransactionExecuted {
-                hash,
-                response,
-            }));
+            key_offset += starknet::core::types::Felt::cairo_serialized_size(&hash);
+            let response = match Vec::<
+                Vec<starknet::core::types::Felt>,
+            >::cairo_deserialize(&event.data, data_offset) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "response",
+                            "TransactionExecuted", e
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += Vec::<
+                    Vec<starknet::core::types::Felt>,
+                >::cairo_serialized_size(&response);
+            return Ok(
+                ControllerEvent::TransactionExecuted(TransactionExecuted {
+                    hash,
+                    response,
+                }),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1459,16 +1723,20 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerAdded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerAdded", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(ControllerEvent::MultipleOwnersEvent(
-                MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
-            ));
+            return Ok(
+                ControllerEvent::MultipleOwnersEvent(
+                    MultipleOwnersEvent::OwnerAdded(OwnerAdded { owner }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1480,16 +1748,20 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerRemoved", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
-            return Ok(ControllerEvent::MultipleOwnersEvent(
-                MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
-            ));
+            return Ok(
+                ControllerEvent::MultipleOwnersEvent(
+                    MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1498,47 +1770,65 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(ControllerEvent::SessionEvent(SessionEvent::SessionRevoked(
-                SessionRevoked { session_hash },
-            )));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                ControllerEvent::SessionEvent(
+                    SessionEvent::SessionRevoked(SessionRevoked { session_hash }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "SessionRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(ControllerEvent::SessionEvent(
-                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
-            ));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                ControllerEvent::SessionEvent(
+                    SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1548,21 +1838,32 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRegistered", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRegistered", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::ExternalOwnersEvent(
-                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::ExternalOwnersEvent(
+                    ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1572,21 +1873,32 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRemoved", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::ExternalOwnersEvent(
-                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::ExternalOwnersEvent(
+                    ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "DelegateAccountChanged")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1596,16 +1908,25 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "DelegateAccountChanged", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "DelegateAccountChanged", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ControllerEvent::DelegateAccountEvents(
-                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged { address }),
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ControllerEvent::DelegateAccountEvents(
+                    DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
+                        address,
+                    }),
+                ),
+            );
         }
         let selector = event.keys[0];
         if selector
@@ -1620,21 +1941,23 @@ impl TryFrom<&starknet::core::types::Event> for ControllerEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "class_hash", "Upgraded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "class_hash",
+                            "Upgraded", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
-            return Ok(ControllerEvent::UpgradeableEvent(UpgradeEvent::Upgraded(
-                Upgraded { class_hash },
-            )));
+            data_offset
+                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            return Ok(
+                ControllerEvent::UpgradeableEvent(
+                    UpgradeEvent::Upgraded(Upgraded { class_hash }),
+                ),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -1671,21 +1994,28 @@ impl cainome::cairo_serde::CairoSerde for DelegateAccountEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(DelegateAccountEvent::DelegateAccountChanged(
-                DelegateAccountChanged::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(
+                    DelegateAccountEvent::DelegateAccountChanged(
+                        DelegateAccountChanged::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "DelegateAccountEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "DelegateAccountEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -1693,7 +2023,9 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "DelegateAccountChanged")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1703,21 +2035,25 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for DelegateAccountEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "DelegateAccountChanged", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "DelegateAccountChanged", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(DelegateAccountEvent::DelegateAccountChanged(
-                DelegateAccountChanged { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
+                    address,
+                }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
@@ -1730,7 +2066,9 @@ impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("DelegateAccountChanged")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "DelegateAccountChanged"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "DelegateAccountChanged")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1740,21 +2078,25 @@ impl TryFrom<&starknet::core::types::Event> for DelegateAccountEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "DelegateAccountChanged", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "DelegateAccountChanged", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(DelegateAccountEvent::DelegateAccountChanged(
-                DelegateAccountChanged { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                DelegateAccountEvent::DelegateAccountChanged(DelegateAccountChanged {
+                    address,
+                }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -1801,24 +2143,38 @@ impl cainome::cairo_serde::CairoSerde for ExternalOwnersEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
-                ExternalOwnerRegistered::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            1usize => Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
-                ExternalOwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(
+                    ExternalOwnersEvent::ExternalOwnerRegistered(
+                        ExternalOwnerRegistered::cairo_deserialize(
+                            __felts,
+                            __offset + 1,
+                        )?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    ExternalOwnersEvent::ExternalOwnerRemoved(
+                        ExternalOwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "ExternalOwnersEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "ExternalOwnersEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -1826,7 +2182,9 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1836,21 +2194,30 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRegistered", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRegistered", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
-                ExternalOwnerRegistered { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
+                    address,
+                }),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1860,21 +2227,25 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRemoved", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
-                ExternalOwnerRemoved { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
+                    address,
+                }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
@@ -1887,7 +2258,9 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1897,21 +2270,30 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRegistered", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRegistered", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ExternalOwnersEvent::ExternalOwnerRegistered(
-                ExternalOwnerRegistered { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ExternalOwnersEvent::ExternalOwnerRegistered(ExternalOwnerRegistered {
+                    address,
+                }),
+            );
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("ExternalOwnerRemoved")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "ExternalOwnerRemoved"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "ExternalOwnerRemoved")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
@@ -1921,21 +2303,25 @@ impl TryFrom<&starknet::core::types::Event> for ExternalOwnersEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "address", "ExternalOwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "address",
+                            "ExternalOwnerRemoved", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ContractAddress::cairo_serialized_size(&address);
-            return Ok(ExternalOwnersEvent::ExternalOwnerRemoved(
-                ExternalOwnerRemoved { address },
-            ));
+            data_offset
+                += cainome::cairo_serde::ContractAddress::cairo_serialized_size(
+                    &address,
+                );
+            return Ok(
+                ExternalOwnersEvent::ExternalOwnerRemoved(ExternalOwnerRemoved {
+                    address,
+                }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -1949,8 +2335,12 @@ impl cainome::cairo_serde::CairoSerde for MultipleOwnersEvent {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         match __rust {
-            MultipleOwnersEvent::OwnerAdded(val) => OwnerAdded::cairo_serialized_size(val) + 1,
-            MultipleOwnersEvent::OwnerRemoved(val) => OwnerRemoved::cairo_serialized_size(val) + 1,
+            MultipleOwnersEvent::OwnerAdded(val) => {
+                OwnerAdded::cairo_serialized_size(val) + 1
+            }
+            MultipleOwnersEvent::OwnerRemoved(val) => {
+                OwnerRemoved::cairo_serialized_size(val) + 1
+            }
             _ => 0,
         }
     }
@@ -1978,24 +2368,35 @@ impl cainome::cairo_serde::CairoSerde for MultipleOwnersEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(MultipleOwnersEvent::OwnerAdded(
-                OwnerAdded::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            1usize => Ok(MultipleOwnersEvent::OwnerRemoved(
-                OwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(
+                    MultipleOwnersEvent::OwnerAdded(
+                        OwnerAdded::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    MultipleOwnersEvent::OwnerRemoved(
+                        OwnerRemoved::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "MultipleOwnersEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "MultipleOwnersEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2010,10 +2411,12 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerAdded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerAdded", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
@@ -2029,19 +2432,18 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerRemoved", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
             return Ok(MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }));
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
@@ -2061,10 +2463,12 @@ impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerAdded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerAdded", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
@@ -2080,19 +2484,18 @@ impl TryFrom<&starknet::core::types::Event> for MultipleOwnersEvent {
             let owner = match Signer::cairo_deserialize(&event.data, data_offset) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "owner", "OwnerRemoved", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "owner",
+                            "OwnerRemoved", e
+                        ),
+                    );
                 }
             };
             data_offset += Signer::cairo_serialized_size(&owner);
             return Ok(MultipleOwnersEvent::OwnerRemoved(OwnerRemoved { owner }));
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2119,25 +2522,27 @@ impl cainome::cairo_serde::CairoSerde for OutsideExecutionV3Event {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "OutsideExecutionV3Event"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!(
+                            "Index not handle for enum {}", "OutsideExecutionV3Event"
+                        ),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for OutsideExecutionV3Event {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for OutsideExecutionV3Event {
@@ -2147,10 +2552,7 @@ impl TryFrom<&starknet::core::types::Event> for OutsideExecutionV3Event {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2195,18 +2597,25 @@ impl cainome::cairo_serde::CairoSerde for Owner {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(Owner::Signer(Signer::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
-            1usize => Ok(Owner::Account(
-                cainome::cairo_serde::ContractAddress::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(Owner::Signer(Signer::cairo_deserialize(__felts, __offset + 1)?))
+            }
+            1usize => {
+                Ok(
+                    Owner::Account(
+                        cainome::cairo_serde::ContractAddress::cairo_deserialize(
+                            __felts,
+                            __offset + 1,
+                        )?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "Owner"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "Owner"),
+                    ),
+                );
             }
         }
     }
@@ -2235,25 +2644,25 @@ impl cainome::cairo_serde::CairoSerde for ReentrancyGuardEvent {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "ReentrancyGuardEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "ReentrancyGuardEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for ReentrancyGuardEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for ReentrancyGuardEvent {
@@ -2263,10 +2672,7 @@ impl TryFrom<&starknet::core::types::Event> for ReentrancyGuardEvent {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2280,7 +2686,9 @@ impl cainome::cairo_serde::CairoSerde for SessionEvent {
     #[inline]
     fn cairo_serialized_size(__rust: &Self::RustType) -> usize {
         match __rust {
-            SessionEvent::SessionRevoked(val) => SessionRevoked::cairo_serialized_size(val) + 1,
+            SessionEvent::SessionRevoked(val) => {
+                SessionRevoked::cairo_serialized_size(val) + 1
+            }
             SessionEvent::SessionRegistered(val) => {
                 SessionRegistered::cairo_serialized_size(val) + 1
             }
@@ -2311,24 +2719,35 @@ impl cainome::cairo_serde::CairoSerde for SessionEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(SessionEvent::SessionRevoked(
-                SessionRevoked::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            1usize => Ok(SessionEvent::SessionRegistered(
-                SessionRegistered::cairo_deserialize(__felts, __offset + 1)?,
-            )),
+            0usize => {
+                Ok(
+                    SessionEvent::SessionRevoked(
+                        SessionRevoked::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    SessionEvent::SessionRegistered(
+                        SessionRegistered::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "SessionEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "SessionEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for SessionEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2340,47 +2759,54 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for SessionEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRevoked(SessionRevoked {
-                session_hash,
-            }));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRevoked(SessionRevoked { session_hash }));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "SessionRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRegistered(SessionRegistered {
-                session_hash,
-            }));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for SessionEvent {
@@ -2397,47 +2823,54 @@ impl TryFrom<&starknet::core::types::Event> for SessionEvent {
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRevoked", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRevoked(SessionRevoked {
-                session_hash,
-            }));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(SessionEvent::SessionRevoked(SessionRevoked { session_hash }));
         }
         let selector = event.keys[0];
         if selector
             == starknet::core::utils::get_selector_from_name("SessionRegistered")
-                .unwrap_or_else(|_| panic!("Invalid selector for {}", "SessionRegistered"))
+                .unwrap_or_else(|_| {
+                    panic!("Invalid selector for {}", "SessionRegistered")
+                })
         {
             let mut key_offset = 0 + 1;
             let mut data_offset = 0;
-            let session_hash =
-                match starknet::core::types::Felt::cairo_deserialize(&event.data, data_offset) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Err(format!(
+            let session_hash = match starknet::core::types::Felt::cairo_deserialize(
+                &event.data,
+                data_offset,
+            ) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(
+                        format!(
                             "Could not deserialize field {} for {}: {:?}",
                             "session_hash", "SessionRegistered", e
-                        ));
-                    }
-                };
-            data_offset += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
-            return Ok(SessionEvent::SessionRegistered(SessionRegistered {
-                session_hash,
-            }));
+                        ),
+                    );
+                }
+            };
+            data_offset
+                += starknet::core::types::Felt::cairo_serialized_size(&session_hash);
+            return Ok(
+                SessionEvent::SessionRegistered(SessionRegistered { session_hash }),
+            );
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2504,31 +2937,47 @@ impl cainome::cairo_serde::CairoSerde for Signer {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(Signer::Starknet(StarknetSigner::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
-            1usize => Ok(Signer::Secp256k1(Secp256k1Signer::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
-            2usize => Ok(Signer::Secp256r1(Secp256r1Signer::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
-            3usize => Ok(Signer::Eip191(Eip191Signer::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
-            4usize => Ok(Signer::Webauthn(WebauthnSigner::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
+            0usize => {
+                Ok(
+                    Signer::Starknet(
+                        StarknetSigner::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    Signer::Secp256k1(
+                        Secp256k1Signer::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            2usize => {
+                Ok(
+                    Signer::Secp256r1(
+                        Secp256r1Signer::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            3usize => {
+                Ok(
+                    Signer::Eip191(
+                        Eip191Signer::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            4usize => {
+                Ok(
+                    Signer::Webauthn(
+                        WebauthnSigner::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "Signer"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "Signer"),
+                    ),
+                );
             }
         }
     }
@@ -2607,32 +3056,62 @@ impl cainome::cairo_serde::CairoSerde for SignerSignature {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(SignerSignature::Starknet(<(
-                StarknetSigner,
-                StarknetSignature,
-            )>::cairo_deserialize(
-                __felts, __offset + 1
-            )?)),
-            1usize => Ok(SignerSignature::Secp256k1(
-                <(Secp256k1Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            2usize => Ok(SignerSignature::Secp256r1(
-                <(Secp256r1Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            3usize => Ok(SignerSignature::Eip191(
-                <(Eip191Signer, Signature)>::cairo_deserialize(__felts, __offset + 1)?,
-            )),
-            4usize => Ok(SignerSignature::Webauthn(<(
-                WebauthnSigner,
-                WebauthnSignature,
-            )>::cairo_deserialize(
-                __felts, __offset + 1
-            )?)),
+            0usize => {
+                Ok(
+                    SignerSignature::Starknet(
+                        <(
+                            StarknetSigner,
+                            StarknetSignature,
+                        )>::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            1usize => {
+                Ok(
+                    SignerSignature::Secp256k1(
+                        <(
+                            Secp256k1Signer,
+                            Signature,
+                        )>::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            2usize => {
+                Ok(
+                    SignerSignature::Secp256r1(
+                        <(
+                            Secp256r1Signer,
+                            Signature,
+                        )>::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            3usize => {
+                Ok(
+                    SignerSignature::Eip191(
+                        <(
+                            Eip191Signer,
+                            Signature,
+                        )>::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
+            4usize => {
+                Ok(
+                    SignerSignature::Webauthn(
+                        <(
+                            WebauthnSigner,
+                            WebauthnSignature,
+                        )>::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "SignerSignature"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "SignerSignature"),
+                    ),
+                );
             }
         }
     }
@@ -2661,25 +3140,25 @@ impl cainome::cairo_serde::CairoSerde for Src5ComponentEvent {
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "Src5ComponentEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "Src5ComponentEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for Src5ComponentEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for Src5ComponentEvent {
@@ -2689,10 +3168,7 @@ impl TryFrom<&starknet::core::types::Event> for Src5ComponentEvent {
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Debug)]
@@ -2727,22 +3203,28 @@ impl cainome::cairo_serde::CairoSerde for UpgradeEvent {
         let __f = __felts[__offset];
         let __index = u128::from_be_bytes(__f.to_bytes_be()[16..].try_into().unwrap());
         match __index as usize {
-            0usize => Ok(UpgradeEvent::Upgraded(Upgraded::cairo_deserialize(
-                __felts,
-                __offset + 1,
-            )?)),
+            0usize => {
+                Ok(
+                    UpgradeEvent::Upgraded(
+                        Upgraded::cairo_deserialize(__felts, __offset + 1)?,
+                    ),
+                )
+            }
             _ => {
-                return Err(cainome::cairo_serde::Error::Deserialize(format!(
-                    "Index not handle for enum {}",
-                    "UpgradeEvent"
-                )));
+                return Err(
+                    cainome::cairo_serde::Error::Deserialize(
+                        format!("Index not handle for enum {}", "UpgradeEvent"),
+                    ),
+                );
             }
         }
     }
 }
 impl TryFrom<&starknet::core::types::EmittedEvent> for UpgradeEvent {
     type Error = String;
-    fn try_from(event: &starknet::core::types::EmittedEvent) -> Result<Self, Self::Error> {
+    fn try_from(
+        event: &starknet::core::types::EmittedEvent,
+    ) -> Result<Self, Self::Error> {
         use cainome::cairo_serde::CairoSerde;
         if event.keys.is_empty() {
             return Err("Event has no key".to_string());
@@ -2760,19 +3242,19 @@ impl TryFrom<&starknet::core::types::EmittedEvent> for UpgradeEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "class_hash", "Upgraded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "class_hash",
+                            "Upgraded", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            data_offset
+                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
             return Ok(UpgradeEvent::Upgraded(Upgraded { class_hash }));
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl TryFrom<&starknet::core::types::Event> for UpgradeEvent {
@@ -2795,19 +3277,19 @@ impl TryFrom<&starknet::core::types::Event> for UpgradeEvent {
             ) {
                 Ok(v) => v,
                 Err(e) => {
-                    return Err(format!(
-                        "Could not deserialize field {} for {}: {:?}",
-                        "class_hash", "Upgraded", e
-                    ));
+                    return Err(
+                        format!(
+                            "Could not deserialize field {} for {}: {:?}", "class_hash",
+                            "Upgraded", e
+                        ),
+                    );
                 }
             };
-            data_offset += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
+            data_offset
+                += cainome::cairo_serde::ClassHash::cairo_serialized_size(&class_hash);
             return Ok(UpgradeEvent::Upgraded(Upgraded { class_hash }));
         }
-        Err(format!(
-            "Could not match any event from keys {:?}",
-            event.keys
-        ))
+        Err(format!("Could not match any event from keys {:?}", event.keys))
     }
 }
 impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
@@ -2822,7 +3304,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         __calldata.extend(SignerSignature::cairo_serialize(signer_signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!("assert_valid_owner_signature"),
+            entry_point_selector: starknet::macros::selector!(
+                "assert_valid_owner_signature"
+            ),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -2831,7 +3315,10 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     #[allow(clippy::too_many_arguments)]
     pub fn delegate_account(
         &self,
-    ) -> cainome::cairo_serde::call::FCall<A::Provider, cainome::cairo_serde::ContractAddress> {
+    ) -> cainome::cairo_serde::call::FCall<
+        A::Provider,
+        cainome::cairo_serde::ContractAddress,
+    > {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         let __call = starknet::core::types::FunctionCall {
@@ -2885,9 +3372,12 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> cainome::cairo_serde::call::FCall<A::Provider, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_external_owner"),
@@ -2921,9 +3411,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(session_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            guid_or_address,
-        ));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_session_registered"),
@@ -2960,7 +3448,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         __calldata.extend(SessionToken::cairo_serialize(token));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!("is_session_signature_valid"),
+            entry_point_selector: starknet::macros::selector!(
+                "is_session_signature_valid"
+            ),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -2973,9 +3463,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> cainome::cairo_serde::call::FCall<A::Provider, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
-            nonce,
-        ));
+        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(nonce));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!(
@@ -2995,9 +3483,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(hash));
-        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            signature,
-        ));
+        __calldata
+            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_valid_signature"),
@@ -3048,7 +3535,10 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     }
     #[allow(clippy::ptr_arg)]
     #[allow(clippy::too_many_arguments)]
-    pub fn __validate___getcall(&self, calls: &Vec<Call>) -> starknet::core::types::Call {
+    pub fn __validate___getcall(
+        &self,
+        calls: &Vec<Call>,
+    ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Vec::<Call>::cairo_serialize(calls));
@@ -3114,9 +3604,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(class_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            contract_address_salt,
-        ));
+        __calldata
+            .extend(starknet::core::types::Felt::cairo_serialize(contract_address_salt));
         __calldata.extend(Owner::cairo_serialize(owner));
         __calldata.extend(Option::<Signer>::cairo_serialize(guardian));
         starknet::core::types::Call {
@@ -3137,9 +3626,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(class_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            contract_address_salt,
-        ));
+        __calldata
+            .extend(starknet::core::types::Felt::cairo_serialize(contract_address_salt));
         __calldata.extend(Owner::cairo_serialize(owner));
         __calldata.extend(Option::<Signer>::cairo_serialize(guardian));
         let __call = starknet::core::types::Call {
@@ -3194,9 +3682,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(OutsideExecutionV3::cairo_serialize(outside_execution));
-        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            signature,
-        ));
+        __calldata
+            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("execute_from_outside_v3"),
@@ -3213,9 +3700,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(OutsideExecutionV3::cairo_serialize(outside_execution));
-        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            signature,
-        ));
+        __calldata
+            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("execute_from_outside_v3"),
@@ -3231,9 +3717,12 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_external_owner"),
@@ -3248,9 +3737,12 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_external_owner"),
@@ -3268,9 +3760,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Session::cairo_serialize(session));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            guid_or_address,
-        ));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_session"),
@@ -3287,9 +3777,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(Session::cairo_serialize(session));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            guid_or_address,
-        ));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("register_session"),
@@ -3305,9 +3793,12 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("remove_external_owner"),
@@ -3322,9 +3813,12 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("remove_external_owner"),
@@ -3396,9 +3890,10 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            delegate_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(delegate_address),
+            );
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("set_delegate_account"),
@@ -3413,9 +3908,10 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            delegate_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(delegate_address),
+            );
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("set_delegate_account"),
@@ -3431,9 +3927,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::core::types::Call {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
-            new_class_hash,
-        ));
+        __calldata
+            .extend(cainome::cairo_serde::ClassHash::cairo_serialize(new_class_hash));
         starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("upgrade"),
@@ -3448,9 +3943,8 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Controller<A> {
     ) -> starknet::accounts::ExecutionV3<A> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ClassHash::cairo_serialize(
-            new_class_hash,
-        ));
+        __calldata
+            .extend(cainome::cairo_serde::ClassHash::cairo_serialize(new_class_hash));
         let __call = starknet::core::types::Call {
             to: self.address,
             selector: starknet::macros::selector!("upgrade"),
@@ -3471,7 +3965,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         __calldata.extend(SignerSignature::cairo_serialize(signer_signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!("assert_valid_owner_signature"),
+            entry_point_selector: starknet::macros::selector!(
+                "assert_valid_owner_signature"
+            ),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -3534,9 +4030,12 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
     ) -> cainome::cairo_serde::call::FCall<P, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(cainome::cairo_serde::ContractAddress::cairo_serialize(
-            external_owner_address,
-        ));
+        __calldata
+            .extend(
+                cainome::cairo_serde::ContractAddress::cairo_serialize(
+                    external_owner_address,
+                ),
+            );
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_external_owner"),
@@ -3570,9 +4069,7 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(session_hash));
-        __calldata.extend(starknet::core::types::Felt::cairo_serialize(
-            guid_or_address,
-        ));
+        __calldata.extend(starknet::core::types::Felt::cairo_serialize(guid_or_address));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_session_registered"),
@@ -3609,7 +4106,9 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         __calldata.extend(SessionToken::cairo_serialize(token));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
-            entry_point_selector: starknet::macros::selector!("is_session_signature_valid"),
+            entry_point_selector: starknet::macros::selector!(
+                "is_session_signature_valid"
+            ),
             calldata: __calldata,
         };
         cainome::cairo_serde::call::FCall::new(__call, self.provider())
@@ -3622,9 +4121,7 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
     ) -> cainome::cairo_serde::call::FCall<P, bool> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
-        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(
-            nonce,
-        ));
+        __calldata.extend(<(starknet::core::types::Felt, u128)>::cairo_serialize(nonce));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!(
@@ -3644,9 +4141,8 @@ impl<P: starknet::providers::Provider + Sync> ControllerReader<P> {
         use cainome::cairo_serde::CairoSerde;
         let mut __calldata = vec![];
         __calldata.extend(starknet::core::types::Felt::cairo_serialize(hash));
-        __calldata.extend(Vec::<starknet::core::types::Felt>::cairo_serialize(
-            signature,
-        ));
+        __calldata
+            .extend(Vec::<starknet::core::types::Felt>::cairo_serialize(signature));
         let __call = starknet::core::types::FunctionCall {
             contract_address: self.address,
             entry_point_selector: starknet::macros::selector!("is_valid_signature"),

--- a/account_sdk/src/abigen/erc_20.rs
+++ b/account_sdk/src/abigen/erc_20.rs
@@ -17,7 +17,7 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> Erc20<A> {
             address,
             account,
             block_id: starknet::core::types::BlockId::Tag(
-                starknet::core::types::BlockTag::Pending,
+                starknet::core::types::BlockTag::PreConfirmed,
             ),
         }
     }
@@ -46,7 +46,7 @@ impl<P: starknet::providers::Provider + Sync> Erc20Reader<P> {
             address,
             provider,
             block_id: starknet::core::types::BlockId::Tag(
-                starknet::core::types::BlockTag::Pending,
+                starknet::core::types::BlockTag::PreConfirmed,
             ),
         }
     }

--- a/account_sdk/src/account/session/account.rs
+++ b/account_sdk/src/account/session/account.rs
@@ -45,7 +45,7 @@ impl SessionAccount {
             signer,
             address,
             chain_id,
-            block_id: BlockId::Tag(BlockTag::Pending),
+            block_id: BlockId::Tag(BlockTag::PreConfirmed),
             session_authorization,
             session,
         }

--- a/account_sdk/src/controller.rs
+++ b/account_sdk/src/controller.rs
@@ -305,7 +305,7 @@ impl Controller {
                             }
                         }
                         AccountError::Provider(ProviderError::StarknetError(
-                            StarknetError::InvalidTransactionNonce,
+                            StarknetError::InvalidTransactionNonce(..),
                         )) => {
                             if retry_count < max_retries {
                                 // Refetch nonce from the provider
@@ -369,7 +369,7 @@ impl Controller {
                     entry_point_selector: selector!("balanceOf"),
                     calldata: vec![address],
                 },
-                BlockId::Tag(BlockTag::Pending),
+                BlockId::Tag(BlockTag::PreConfirmed),
             )
             .await
             .map_err(ControllerError::ProviderError)?;
@@ -473,7 +473,7 @@ impl ConnectedAccount for Controller {
     }
 
     fn block_id(&self) -> BlockId {
-        BlockId::Tag(BlockTag::Pending)
+        BlockId::Tag(BlockTag::PreConfirmed)
     }
 
     async fn get_nonce(&self) -> Result<Felt, ProviderError> {

--- a/account_sdk/src/factory.rs
+++ b/account_sdk/src/factory.rs
@@ -36,7 +36,7 @@ impl ControllerFactory {
             chain_id,
             owner,
             provider,
-            block_id: BlockId::Tag(BlockTag::Pending),
+            block_id: BlockId::Tag(BlockTag::PreConfirmed),
         }
     }
 

--- a/account_sdk/src/provider.rs
+++ b/account_sdk/src/provider.rs
@@ -4,10 +4,11 @@ use nom::AsChar;
 use starknet::core::types::{
     BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
-    ContractClass, ContractExecutionError, DeclareTransactionResult,
+    ConfirmedBlockId, ContractClass, ContractExecutionError, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
-    Hash256, InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, MaybePendingStateUpdate, MsgFromL1, SimulatedTransaction,
+    Hash256, InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+    MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+    MaybePreConfirmedStateUpdate, MessageFeeEstimate, MsgFromL1, SimulatedTransaction,
     SimulationFlag, SimulationFlagForEstimateFee, SyncStatusType, Transaction,
     TransactionExecutionErrorData, TransactionReceiptWithBlockInfo, TransactionStatus,
     TransactionTrace, TransactionTraceWithHash,
@@ -114,7 +115,7 @@ impl Provider for CartridgeJsonRpcProvider {
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -124,7 +125,7 @@ impl Provider for CartridgeJsonRpcProvider {
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -134,7 +135,7 @@ impl Provider for CartridgeJsonRpcProvider {
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -144,7 +145,7 @@ impl Provider for CartridgeJsonRpcProvider {
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -297,7 +298,7 @@ impl Provider for CartridgeJsonRpcProvider {
         &self,
         message: M,
         block_id: B,
-    ) -> Result<FeeEstimate, ProviderError>
+    ) -> Result<MessageFeeEstimate, ProviderError>
     where
         M: AsRef<MsgFromL1> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
@@ -422,7 +423,7 @@ impl Provider for CartridgeJsonRpcProvider {
         block_id: B,
     ) -> Result<Vec<TransactionTraceWithHash>, ProviderError>
     where
-        B: AsRef<BlockId> + Send + Sync,
+        B: AsRef<ConfirmedBlockId> + Send + Sync,
     {
         self.inner.trace_block_transactions(block_id).await
     }
@@ -440,7 +441,7 @@ impl Provider for CartridgeJsonRpcProvider {
     async fn get_messages_status(
         &self,
         transaction_hash: Hash256,
-    ) -> Result<Vec<starknet::core::types::MessageWithStatus>, ProviderError> {
+    ) -> Result<Vec<starknet::core::types::MessageStatus>, ProviderError> {
         self.inner.get_messages_status(transaction_hash).await
     }
 

--- a/account_sdk/src/session_test.rs
+++ b/account_sdk/src/session_test.rs
@@ -2,9 +2,7 @@ use cainome::cairo_serde::{ContractAddress, U256};
 use cainome_cairo_serde::Zeroable;
 use starknet::{
     accounts::{Account, AccountError, ConnectedAccount},
-    core::types::{
-        BlockId, BlockTag, FeeEstimate, PriceUnit, StarknetError, TransactionExecutionErrorData,
-    },
+    core::types::{BlockId, BlockTag, FeeEstimate, StarknetError, TransactionExecutionErrorData},
     macros::{felt, selector},
     providers::{Provider, ProviderError},
     signers::SigningKey,
@@ -237,7 +235,6 @@ async fn test_create_and_use_registered_session() {
         l1_data_gas_consumed: 0,
         l1_data_gas_price: 0,
         overall_fee: 57780000000000_u128,
-        unit: PriceUnit::Fri,
     };
     let txn = controller
         .register_session(

--- a/account_sdk/src/tests/runners/katana.rs
+++ b/account_sdk/src/tests/runners/katana.rs
@@ -155,7 +155,7 @@ impl KatanaRunner {
 
         if self
             .client()
-            .get_class(BlockId::Tag(BlockTag::Pending), class_hash)
+            .get_class(BlockId::Tag(BlockTag::PreConfirmed), class_hash)
             .await
             .is_err()
         {
@@ -223,7 +223,7 @@ where
         encoding,
     );
 
-    account.set_block_id(BlockId::Tag(BlockTag::Pending)); // For fetching valid nonce
+    account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed)); // For fetching valid nonce
     account
 }
 

--- a/account_sdk/src/transaction_waiter.rs
+++ b/account_sdk/src/transaction_waiter.rs
@@ -173,7 +173,7 @@ where
             let transaction = self.provider.get_transaction_receipt(self.tx_hash).await;
             match transaction {
                 Ok(receipt) => match &receipt.block {
-                    ReceiptBlock::Pending => {
+                    ReceiptBlock::PreConfirmed => {
                         if self.finality_status.is_none() {
                             if self.must_succeed {
                                 return match execution_status_from_receipt(&receipt.receipt) {

--- a/account_sdk/src/upgrade_test.rs
+++ b/account_sdk/src/upgrade_test.rs
@@ -31,7 +31,7 @@ async fn test_controller_upgrade() {
 
     let hash = controller
         .provider()
-        .get_class_hash_at(BlockId::Tag(BlockTag::Pending), controller.address())
+        .get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), controller.address())
         .await
         .unwrap();
 
@@ -49,7 +49,7 @@ async fn test_controller_upgrade() {
 
     let hash = controller
         .provider()
-        .get_class_hash_at(BlockId::Tag(BlockTag::Pending), controller.address())
+        .get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), controller.address())
         .await
         .unwrap();
 


### PR DESCRIPTION
This upgrade involves bumping the `starknet` crate to version [`v0.17.0-rc.2`](https://crates.io/crates/starknet/0.17.0-rc.2).

For some context, `account_sdk` is a dependency for both `katana`, and `dojo` (re-exported thru the `slot` crate). 