### PR TITLE
Fix CI paths-filter action git configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,18 @@ jobs:
       image: ghcr.io/dojoengine/katana:v1.6.0-alpha.1
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           apt-get update
           apt-get install -y git build-essential gcc libssl-dev pkg-config
-      - run: git config --global --add safe.directory '*'
-      - uses: dorny/paths-filter@v3
+      - name: Configure git
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+      - uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |


### PR DESCRIPTION
## Summary
Fixes the controller-rs CI failure with `dorny/paths-filter@v3` where git commands fail with exit code 128.

## Root Cause
The paths-filter action was failing because it couldn't properly access git history in the Docker container environment. The error occurred when trying to determine the current git ref for change detection.

## Changes Made
- **Add `fetch-depth: 0`** to checkout action to ensure full git history is available
- **Configure git user credentials** before running paths-filter to prevent authentication issues
- **Downgrade paths-filter from v3 to v2** for better container compatibility
- **Consolidate git configuration** into a dedicated step for clarity

## Technical Details
The issue was caused by:
1. Limited git history from shallow checkout (default fetch-depth: 1)
2. Missing git user configuration in the container environment
3. Potential compatibility issues with paths-filter@v3 in Docker containers

## Testing
This fix addresses the specific error:
```
/usr/bin/docker exec ... sh -c "cat /etc/*release | grep ^ID"
Get current git ref
Error: The process '/usr/bin/git' failed with exit code 128
```

The changes ensure git is properly configured before the paths-filter action attempts to analyze repository changes.

🤖 Generated with [Claude Code](https://claude.ai/code)