### PR TITLE
feat: Controller Factory pattern

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,12 +20,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           target: wasm32-unknown-unknown
-      - run: |
-          cd account_sdk
-          cargo build -r --target wasm32-unknown-unknown -p account_sdk
-          cd ../account-wasm
-          cargo install --locked wasm-pack
-          ./build.sh
+      - name: Install wasm-pack
+        run: cargo install --locked wasm-pack
+      - name: Build account-wasm
+        working-directory: account-wasm
+        run: ./build.sh
 
   ensure-windows:
     runs-on: windows-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,6 +23,8 @@ jobs:
       - run: |
           cd account_sdk
           cargo build -r --target wasm32-unknown-unknown -p account_sdk
+          cd ../account-wasm
+          ./build.sh
 
   ensure-windows:
     runs-on: windows-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,6 +24,7 @@ jobs:
           cd account_sdk
           cargo build -r --target wasm32-unknown-unknown -p account_sdk
           cd ../account-wasm
+          cargo install --locked wasm-pack
           ./build.sh
 
   ensure-windows:

--- a/account-wasm/Cargo.toml
+++ b/account-wasm/Cargo.toml
@@ -71,3 +71,7 @@ console_error_panic_hook = []
 controller_account = []
 session_account = []
 wee_alloc = ["dep:wee_alloc"]
+
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["--enable-bulk-memory", "--all-features" ]

--- a/account-wasm/build.sh
+++ b/account-wasm/build.sh
@@ -8,19 +8,20 @@ if ! command -v wasm-opt &>/dev/null; then
     npm install -g wasm-opt
 fi
 
-# Build account bundle
-RUSTFLAGS='-C link-arg=-s -C opt-level=z -C codegen-units=1' \
-    wasm-pack build --target bundler --out-dir ./pkg-controller --release --features "controller_account,wee_alloc"
+# Change to the account-wasm directory
+cd "$(dirname "$0")"
 
-# Optimize controller bundle
-wasm-opt -Oz --enable-bulk-memory -o ./pkg-controller/account_wasm_bg.wasm ./pkg-controller/account_wasm_bg.wasm
+# Create output directories if they don't exist
+mkdir -p pkg-controller
+mkdir -p pkg-session
+
+# Build account bundle
+RUSTFLAGS='-C link-arg=-s -C opt-level=z -C codegen-units=1 -C target-feature=+bulk-memory' \
+    wasm-pack build --target bundler --out-dir "$(pwd)/pkg-controller" --release --features "controller_account,wee_alloc"
 
 # Build session bundle
-RUSTFLAGS='-C link-arg=-s -C opt-level=z -C codegen-units=1' \
-    wasm-pack build --target bundler --out-dir ./pkg-session --out-name session_wasm --release --features "session_account,wee_alloc"
-
-# Optimize session bundle
-wasm-opt -Oz --enable-bulk-memory -o ./pkg-session/session_wasm_bg.wasm ./pkg-session/session_wasm_bg.wasm
+RUSTFLAGS='-C link-arg=-s -C opt-level=z -C codegen-units=1 -C target-feature=+bulk-memory' \
+    wasm-pack build --target bundler --out-dir "$(pwd)/pkg-session" --out-name session_wasm --release --features "session_account,wee_alloc"
 
 rm -f pkg-controller/.gitignore
 rm -f pkg-session/.gitignore

--- a/account-wasm/src/account.rs
+++ b/account-wasm/src/account.rs
@@ -7,7 +7,7 @@ use account_sdk::storage::selectors::Selectors;
 use account_sdk::storage::StorageBackend;
 
 use account_sdk::transaction_waiter::TransactionWaiter;
-use cainome::cairo_serde::{CairoSerde, Zeroable};
+use cainome::cairo_serde::Zeroable;
 use serde_wasm_bindgen::to_value;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag, Call, FeeEstimate, FunctionCall, TypedData};

--- a/account-wasm/src/account_factory.rs
+++ b/account-wasm/src/account_factory.rs
@@ -1,0 +1,127 @@
+use account_sdk::controller::Controller;
+use account_sdk::errors::ControllerError;
+use account_sdk::storage::selectors::Selectors;
+use account_sdk::storage::{ControllerMetadata, StorageBackend};
+
+use starknet_crypto::Felt;
+use url::Url;
+use wasm_bindgen::prelude::*;
+
+use crate::account::{CartridgeAccount, CartridgeAccountWithMeta};
+use crate::errors::JsControllerError;
+use crate::types::owner::Owner;
+use crate::types::session::AuthorizedSession;
+use crate::types::signer::try_find_webauthn_signer_in_signer_signature;
+use crate::types::JsFelt;
+
+#[wasm_bindgen]
+pub struct ControllerBuilderFactory;
+
+#[wasm_bindgen]
+impl ControllerBuilderFactory {
+    pub fn from_storage(
+        app_id: String,
+        cartridge_api_url: String,
+    ) -> crate::account::Result<Option<CartridgeAccountWithMeta>> {
+        CartridgeAccount::from_storage(app_id, cartridge_api_url)
+    }
+
+    #[allow(clippy::new_ret_no_self, clippy::too_many_arguments)]
+    #[wasm_bindgen(js_name = login)]
+    pub async fn login(
+        app_id: String,
+        username: String,
+        class_hash: JsFelt,
+        rpc_url: String,
+        chain_id: JsFelt,
+        address: JsFelt,
+        owner: Owner,
+        cartridge_api_url: String,
+        session_expires_at_s: u64,
+        is_controller_registered: Option<bool>,
+    ) -> crate::account::Result<LoginResult> {
+        let class_hash_felt: Felt = class_hash.try_into()?;
+        let chain_id_felt: Felt = chain_id.try_into()?;
+        let rpc_url: Url = Url::parse(&rpc_url)?;
+        let address_felt: Felt = address.try_into()?;
+        let mut controller = Controller::new(
+            app_id.clone(),
+            username,
+            class_hash_felt,
+            rpc_url,
+            owner.clone().into(),
+            address_felt,
+            chain_id_felt,
+        );
+        let session_account = controller
+            .create_wildcard_session(session_expires_at_s)
+            .await?;
+
+        if owner.is_signer() && owner.signer.as_ref().unwrap().is_webauthns() {
+            let webauthn_signer = try_find_webauthn_signer_in_signer_signature(
+                owner.signer.unwrap().webauthns.unwrap(),
+                session_account.session_authorization.clone(),
+            )?;
+            controller.owner = account_sdk::signers::Owner::Signer(
+                account_sdk::signers::Signer::Webauthn(webauthn_signer.clone().try_into()?),
+            );
+            // As we've changed the owner, we need to update the controller in the storage.
+            controller
+                .storage
+                .set_controller(
+                    app_id.as_str(),
+                    &chain_id_felt,
+                    address_felt,
+                    ControllerMetadata::from(&controller),
+                )
+                .expect("Should store controller");
+        }
+
+        if is_controller_registered.unwrap_or(false) {
+            let controller_response = controller
+                .register_session_with_cartridge(
+                    &session_account.session,
+                    &session_account.session_authorization,
+                    cartridge_api_url.clone(),
+                )
+                .await;
+
+            if let Err(e) = controller_response {
+                let address = controller.address;
+                let app_id = controller.app_id.clone();
+                let chain_id = controller.chain_id;
+
+                controller
+                    .storage
+                    .remove(&Selectors::session(&address, &app_id, &chain_id))
+                    .map_err(|e| JsControllerError::from(ControllerError::StorageError(e)))?;
+
+                return Err(JsControllerError::from(e).into());
+            }
+        }
+
+        let account_with_meta = CartridgeAccountWithMeta::new(controller, cartridge_api_url);
+        let authorized_session: AuthorizedSession = session_account.into();
+        Ok(LoginResult {
+            account: account_with_meta,
+            session: authorized_session,
+        })
+    }
+}
+
+#[wasm_bindgen]
+pub struct LoginResult {
+    account: CartridgeAccountWithMeta,
+    session: AuthorizedSession,
+}
+
+#[wasm_bindgen]
+impl LoginResult {
+    #[wasm_bindgen(js_name = intoValues)]
+    pub fn into_values(self) -> web_sys::js_sys::Array {
+        let array = web_sys::js_sys::Array::new();
+        array.push(&JsValue::from(self.account));
+        array.push(&JsValue::from(self.session));
+        array
+    }
+}

--- a/account-wasm/src/errors.rs
+++ b/account-wasm/src/errors.rs
@@ -99,6 +99,8 @@ pub enum ErrorCode {
     PolicyChainIdMismatch = 136,
     InvalidOwner = 137,
     GasPriceTooHigh = 138,
+    TransactionTimeout = 139,
+    ConversionError = 140,
 }
 
 impl From<ControllerError> for JsControllerError {
@@ -201,13 +203,18 @@ impl From<ControllerError> for JsControllerError {
                 data: None,
             },
             ControllerError::TransactionTimeout => JsControllerError {
-                code: ErrorCode::StarknetUnexpectedError,
+                code: ErrorCode::TransactionTimeout,
                 message: "Transaction timeout".to_string(),
                 data: None,
             },
             ControllerError::ParseCairoShortString(e) => JsControllerError {
                 code: ErrorCode::StarknetUnexpectedError,
                 message: format!("Failed to parse cairo short string: {}", e),
+                data: None,
+            },
+            ControllerError::ConversionError(e) => JsControllerError {
+                code: ErrorCode::ConversionError,
+                message: e.to_string(),
                 data: None,
             },
         }

--- a/account-wasm/src/lib.rs
+++ b/account-wasm/src/lib.rs
@@ -4,6 +4,9 @@ mod alloc;
 pub mod account;
 
 #[cfg(feature = "controller_account")]
+mod account_factory;
+
+#[cfg(feature = "controller_account")]
 mod owner;
 
 #[cfg(feature = "session_account")]

--- a/account-wasm/src/types/owner.rs
+++ b/account-wasm/src/types/owner.rs
@@ -15,6 +15,24 @@ pub struct Owner {
     pub account: Option<JsFelt>,
 }
 
+impl Owner {
+    pub fn is_empty(&self) -> bool {
+        self.signer.is_none() && self.account.is_none()
+    }
+
+    pub fn is_signer(&self) -> bool {
+        self.signer.is_some() && self.account.is_none()
+    }
+
+    pub fn is_account(&self) -> bool {
+        self.signer.is_none() && self.account.is_some()
+    }
+
+    pub fn is_signer_and_account(&self) -> bool {
+        self.signer.is_some() && self.account.is_some()
+    }
+}
+
 impl From<Owner> for SdkOwner {
     fn from(owner: Owner) -> Self {
         if let Some(signer) = owner.signer {

--- a/account-wasm/src/types/session.rs
+++ b/account-wasm/src/types/session.rs
@@ -83,6 +83,28 @@ pub struct AuthorizedSession {
     pub guardian_key_guid: JsFelt,
 }
 
+impl From<account_sdk::account::session::account::SessionAccount> for AuthorizedSession {
+    fn from(value: account_sdk::account::session::account::SessionAccount) -> Self {
+        AuthorizedSession {
+            session: value.session.clone().into(),
+            authorization: Some(
+                value
+                    .session_authorization
+                    .clone()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+            ),
+            is_registered: false,
+            expires_at: value.session.inner.expires_at,
+            allowed_policies_root: value.session.inner.allowed_policies_root.into(),
+            metadata_hash: value.session.inner.metadata_hash.into(),
+            session_key_guid: value.session.inner.session_key_guid.into(),
+            guardian_key_guid: value.session.inner.guardian_key_guid.into(),
+        }
+    }
+}
+
 impl TryFrom<JsValue> for AuthorizedSession {
     type Error = EncodingError;
 

--- a/account_sdk/Cargo.toml
+++ b/account_sdk/Cargo.toml
@@ -126,3 +126,7 @@ filestorage = ["dirs"]
 name = "bench"
 path = "cmd/bench.rs"
 required-features = ["bench"]
+
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["--enable-bulk-memory", "--all-features" ]

--- a/account_sdk/src/errors.rs
+++ b/account_sdk/src/errors.rs
@@ -76,4 +76,7 @@ pub enum ControllerError {
 
     #[error("Failed to parse cairo short string: {0}")]
     ParseCairoShortString(#[from] starknet::core::utils::ParseCairoShortStringError),
+
+    #[error("Conversion error: {0}")]
+    ConversionError(String),
 }

--- a/account_sdk/src/signers/mod.rs
+++ b/account_sdk/src/signers/mod.rs
@@ -117,8 +117,8 @@ impl From<Signer> for crate::abigen::controller::Signer {
             #[cfg(feature = "webauthn")]
             Signer::Webauthn(s) => crate::abigen::controller::Signer::Webauthn(s.into()),
             #[cfg(feature = "webauthn")]
-            Signer::Webauthns(s) => {
-                crate::abigen::controller::Signer::Webauthn(s[0].clone().into())
+            Signer::Webauthns(_) => {
+                panic!("Webauthns is not supported");
             }
             Signer::Eip191(s) => {
                 crate::abigen::controller::Signer::Eip191(crate::abigen::controller::Eip191Signer {


### PR DESCRIPTION
### Context: 

With the new `Webauthns` signer, the controller is first created with an array of webauthn owners. It is only at the login stage that we then know which passkey the user chooses.
This requires us to change the way the controller is created.

We now use a factory pattern

The PR related to this change in the controller is [here](https://github.com/cartridge-gg/controller/pull/1891)