### PR TITLE
fix: replace unsafe unwrap with proper error handling in API client

### DIFF
--- a/account_sdk/src/api.rs
+++ b/account_sdk/src/api.rs
@@ -44,7 +44,14 @@ impl Client {
         if let Some(errors) = res.errors {
             Err(ControllerError::Api(GraphQLErrors(errors)))
         } else {
-            Ok(res.data.unwrap())
+            res.data.ok_or_else(|| {
+                ControllerError::Api(GraphQLErrors(vec![graphql_client::Error {
+                    message: "No data in response".to_string(),
+                    locations: None,
+                    path: None,
+                    extensions: None,
+                }]))
+            })
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with `.ok_or_else()` in the GraphQL query method to properly handle cases where the response doesn't contain data
- This prevents potential panics and returns a descriptive error message instead
- Fixes the unsafe unwrap at [account_sdk/src/api.rs#L47](https://github.com/cartridge-gg/controller-rs/blob/5187097c0eda08555b62736a3c95741a9e279237/account_sdk/src/api.rs#L47)

## Test plan
- [x] Code compiles successfully (`cargo check`)
- [x] Clippy passes without warnings (`cargo clippy`)
- [ ] Existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.ai/code)