### PR TITLE
refactor: fetch chain_id from RPC provider

### DIFF
--- a/account_sdk/cmd/bench.rs
+++ b/account_sdk/cmd/bench.rs
@@ -63,8 +63,9 @@ async fn main() {
         rpc_url,
         owner.clone(),
         address,
-        chain_id,
-    );
+    )
+    .await
+    .expect("controller construction should succeed");
 
     match factory
         .deploy_v3(salt)

--- a/account_sdk/src/controller_test.rs
+++ b/account_sdk/src/controller_test.rs
@@ -48,8 +48,9 @@ async fn test_deploy_controller() {
         runner.rpc_url.clone(),
         owner.clone(),
         address,
-        chain_id,
-    );
+    )
+    .await
+    .unwrap();
 
     runner.fund(&address).await;
 
@@ -97,8 +98,9 @@ async fn test_controller_not_deployed() {
         runner.rpc_url.clone(),
         Owner::Signer(signer.clone()),
         felt!("0xdeadbeef"),
-        chain_id,
-    );
+    )
+    .await
+    .unwrap();
 
     let recipient = ContractAddress(felt!("0x18301129"));
     let amount = U256 { low: 0, high: 0 };
@@ -139,8 +141,9 @@ async fn test_controller_nonce_mismatch_recovery() {
         runner.rpc_url.clone(),
         Owner::Signer(signer.clone()),
         controller1.address,
-        chain_id,
-    );
+    )
+    .await
+    .unwrap();
 
     // Send a transaction using controller1
     let recipient = ContractAddress(felt!("0x18301129"));
@@ -240,7 +243,7 @@ async fn test_controller_storage() {
     assert!(storage_file.exists(), "Storage file was not created");
 
     // Initialize a new controller from storage
-    let loaded_controller = Controller::from_storage(app_id).unwrap().unwrap();
+    let loaded_controller = Controller::from_storage(app_id).await.unwrap().unwrap();
 
     // Verify that the loaded controller matches the original
     assert_eq!(loaded_controller.username, controller.username);

--- a/account_sdk/src/controller_test.rs
+++ b/account_sdk/src/controller_test.rs
@@ -88,8 +88,6 @@ async fn test_controller_not_deployed() {
             Version::LATEST,
         )
         .await;
-    let chain_id = runner.client().chain_id().await.unwrap();
-
     // Create a controller that is not deployed
     let undeployed_controller = Controller::new(
         "app_id".to_string(),
@@ -130,8 +128,6 @@ async fn test_controller_nonce_mismatch_recovery() {
             Version::LATEST,
         )
         .await;
-
-    let chain_id = runner.client().chain_id().await.unwrap();
 
     // Create the second controller with the same credentials and address
     let mut controller2 = Controller::new(

--- a/account_sdk/src/storage/storage_test.rs
+++ b/account_sdk/src/storage/storage_test.rs
@@ -9,8 +9,8 @@ mod tests {
     use starknet_crypto::Felt;
     use url::Url;
 
-    #[test]
-    fn test_storage_serialization_error() {
+    #[tokio::test]
+    async fn test_storage_serialization_error() {
         let app_id = "app_id".to_string();
         let mut controller = Controller::new(
             app_id.clone(),
@@ -19,8 +19,9 @@ mod tests {
             Url::parse("https://rpc.katana.cartridge.gg").unwrap(),
             Owner::Signer(Signer::new_starknet_random()),
             Felt::ONE,
-            Felt::ZERO,
-        );
+        )
+        .await
+        .unwrap();
 
         // Create invalid JSON
         let corrupted_data = json!({

--- a/account_sdk/src/storage/storage_test.rs
+++ b/account_sdk/src/storage/storage_test.rs
@@ -1,27 +1,23 @@
 #[cfg(test)]
 mod tests {
-    use crate::artifacts::{Version, CONTROLLERS};
-    use crate::controller::Controller;
+    use crate::artifacts::Version;
     use crate::signers::{Owner, Signer};
     use crate::storage::selectors::Selectors;
     use crate::storage::{StorageBackend, StorageError};
+    use crate::tests::runners::katana::KatanaRunner;
     use serde_json::json;
-    use starknet_crypto::Felt;
-    use url::Url;
 
     #[tokio::test]
     async fn test_storage_serialization_error() {
         let app_id = "app_id".to_string();
-        let mut controller = Controller::new(
-            app_id.clone(),
-            "username".to_string(),
-            CONTROLLERS[&Version::LATEST].hash,
-            Url::parse("https://rpc.katana.cartridge.gg").unwrap(),
-            Owner::Signer(Signer::new_starknet_random()),
-            Felt::ONE,
-        )
-        .await
-        .unwrap();
+        let runner = KatanaRunner::load();
+        let mut controller = runner
+            .deploy_controller(
+                "username".to_string(),
+                Owner::Signer(Signer::new_starknet_random()),
+                Version::LATEST,
+            )
+            .await;
 
         // Create invalid JSON
         let corrupted_data = json!({

--- a/account_sdk/src/tests/outside_execution_test.rs
+++ b/account_sdk/src/tests/outside_execution_test.rs
@@ -2,7 +2,6 @@ use cainome::cairo_serde::{CairoSerde, ContractAddress, U256};
 use starknet::{
     accounts::Account,
     macros::{felt, selector},
-    providers::Provider,
     signers::SigningKey,
 };
 

--- a/account_sdk/src/tests/outside_execution_test.rs
+++ b/account_sdk/src/tests/outside_execution_test.rs
@@ -167,8 +167,9 @@ async fn test_verify_execute_paymaster_should_fail() {
         runner.rpc_url.clone(),
         Owner::Signer(Signer::new_starknet_random()),
         controller.address(),
-        runner.client().chain_id().await.unwrap(),
-    );
+    )
+    .await
+    .unwrap();
 
     let outside_execution = wrong_account
         .sign_outside_execution(OutsideExecution::V3(outside_execution.clone()))

--- a/account_sdk/src/tests/owner_test.rs
+++ b/account_sdk/src/tests/owner_test.rs
@@ -12,7 +12,6 @@ use cainome::cairo_serde::{ContractAddress, U256};
 use starknet::{
     accounts::{Account, AccountError},
     macros::{felt, selector},
-    providers::Provider,
 };
 use starknet_crypto::Felt;
 

--- a/account_sdk/src/tests/owner_test.rs
+++ b/account_sdk/src/tests/owner_test.rs
@@ -320,8 +320,9 @@ async fn test_change_owner_invalidate_old_sessions() {
         runner.rpc_url.clone(),
         Owner::Signer(new_signer.clone()),
         controller.address(),
-        runner.client().chain_id().await.unwrap(),
-    );
+    )
+    .await
+    .unwrap();
 
     let session_account = controller
         .create_session(vec![transfer_method], u64::MAX)

--- a/account_sdk/src/tests/runners/katana.rs
+++ b/account_sdk/src/tests/runners/katana.rs
@@ -194,8 +194,9 @@ impl KatanaRunner {
             self.rpc_url.clone(),
             owner,
             address,
-            self.chain_id,
         )
+        .await
+        .expect("controller creation with storage should succeed")
     }
 }
 


### PR DESCRIPTION
## Summary
- Remove chain_id parameter from Controller constructors
- Fetch chain_id directly from RPC provider instead
- Make constructors async to support fetching chain_id

## Changes
This PR refactors how chain_id is handled in the Controller:
- Controllers now fetch chain_id from the RPC provider during initialization
- Removes the need for callers to provide chain_id as a parameter
- Ensures chain_id is always consistent with the connected network
- Updates all tests and WASM bindings to use async constructors

## Test plan
- [ ] Run `cargo test` to ensure all tests pass
- [ ] Run `make lint-rust` to check code formatting
- [ ] Build WASM packages with `cd account-wasm && ./build.sh`
- [ ] Verify controller creation works with the new async API

🤖 Generated with [Claude Code](https://claude.ai/code)