### PR TITLE
test: improve paymaster fallback test with forced failure simulation

### DIFF
--- a/account_sdk/src/execute_from_outside_test.rs
+++ b/account_sdk/src/execute_from_outside_test.rs
@@ -152,6 +152,16 @@ async fn test_execute_from_outside_with_session() {
 async fn test_paymaster_fallback() {
     use crate::errors::ControllerError;
     use crate::execute_from_outside::FeeSource;
+    use crate::provider::ExecuteFromOutsideError;
+    use crate::tests::runners::cartridge::CartridgeProxy;
+
+    struct ResetPaymasterFailures;
+
+    impl Drop for ResetPaymasterFailures {
+        fn drop(&mut self) {
+            CartridgeProxy::force_paymaster_failures(0);
+        }
+    }
 
     let signer = Signer::new_starknet_random();
     let runner = KatanaRunner::load();
@@ -165,36 +175,45 @@ async fn test_paymaster_fallback() {
 
     let recipient = ContractAddress(felt!("0x18301129"));
     let amount = U256 { low: 10, high: 0 };
-    let erc20 = Erc20::new(*FEE_TOKEN_ADDRESS, &controller);
-    let tx = erc20.transfer_getcall(&recipient, &amount);
+    let tx = {
+        let erc20 = Erc20::new(*FEE_TOKEN_ADDRESS, &controller);
+        erc20.transfer_getcall(&recipient, &amount)
+    };
 
-    // Mock a scenario where paymaster is not supported by checking the error
-    // In a real scenario, this would be when the paymaster service returns an error
-    let paymaster_result = controller
+    let _reset_paymaster_failures = ResetPaymasterFailures;
+    CartridgeProxy::force_paymaster_failures(1);
+
+    let paymaster_error = controller
         .execute_from_outside_v3(vec![tx.clone()], Some(FeeSource::Paymaster))
-        .await;
+        .await
+        .expect_err("expected paymaster execution to fail");
 
-    // The actual paymaster might work in test environment,
-    // but the code is designed to handle failures gracefully
-    match paymaster_result {
-        Ok(_) => {
-            // Paymaster worked in test environment
+    match paymaster_error {
+        ControllerError::PaymasterError(
+            ExecuteFromOutsideError::ExecuteFromOutsideNotSupported(message),
+        ) => {
+            assert_eq!(message, "Paymaster not supported");
         }
-        Err(ControllerError::PaymasterError(_)) | Err(ControllerError::PaymasterNotSupported) => {
-            // This is the expected path when paymaster is not supported
-            // The code should fall back to user-pays flow
-            let estimate = controller
-                .estimate_invoke_fee(vec![tx.clone()])
-                .await
-                .unwrap();
-            let result = controller.execute(vec![tx], Some(estimate), None).await;
-            assert!(result.is_ok(), "Fallback to user-pays should work");
-        }
-        Err(e) => {
-            // Other errors should not occur
-            panic!("Unexpected error: {:?}", e);
-        }
+        other => panic!("unexpected error variant {other:?}"),
     }
+
+    let estimate = controller
+        .estimate_invoke_fee(vec![tx.clone()])
+        .await
+        .unwrap();
+    let fallback_tx = controller
+        .execute(vec![tx], Some(estimate), None)
+        .await
+        .expect("fallback execution should succeed");
+
+    TransactionWaiter::new(fallback_tx.transaction_hash, runner.client())
+        .wait()
+        .await
+        .unwrap();
+
+    let erc20 = Erc20::new(*FEE_TOKEN_ADDRESS, &controller);
+    let fallback_balance = erc20.balanceOf(&recipient).call().await.unwrap();
+    assert_eq!(fallback_balance, amount);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Added test infrastructure to simulate paymaster failures in the CartridgeProxy
- Enhanced `test_paymaster_fallback` to explicitly verify error handling and fallback execution
- Implemented atomic counter mechanism to control the number of simulated failures

## Test plan
- [x] Run `cargo test test_paymaster_fallback` to verify the test passes
- [x] Verify that the fallback mechanism correctly switches to user-pays flow when paymaster fails
- [x] Ensure the failure counter resets properly after test completion

🤖 Generated with [Claude Code](https://claude.ai/code)