### PR TITLE
fix: properly map insufficient credits error to PaymasterNotSupported

### DIFF
--- a/account_sdk/src/provider.rs
+++ b/account_sdk/src/provider.rs
@@ -672,4 +672,28 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_insufficient_credits_error_mapping() {
+        let error = JsonRpcError {
+            code: -32003,
+            message: "insufficient credits and no applicable paymaster found".to_string(),
+            data: None,
+        };
+        let error_from_json = ExecuteFromOutsideError::from(error);
+        match error_from_json {
+            ExecuteFromOutsideError::ExecuteFromOutsideNotSupported(msg) => {
+                assert_eq!(
+                    msg,
+                    "insufficient credits and no applicable paymaster found"
+                );
+            }
+            _ => {
+                panic!(
+                    "Expected ExecuteFromOutsideNotSupported, got: {:?}",
+                    error_from_json
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the error mapping for the paymaster "insufficient credits" error in `try_session_execute`. When the server returns a JSON-RPC error with code `-32003` and message "insufficient credits and no applicable paymaster found", it now properly maps to `ControllerError::PaymasterNotSupported`, enabling the fallback to user-pays flow.

## Changes
- Modified `execute_from_outside_v2` and `execute_from_outside_v3` to explicitly map `ExecuteFromOutsideNotSupported` to `PaymasterNotSupported`
- Added comprehensive unit tests in both `execute_from_outside.rs` and `provider.rs` to verify error mapping logic
- Ensures backward compatibility with existing error handling (the `is_paymaster_not_supported` helper already checks for both error variants)

## Error Flow
1. **Server Response**: `{"error": {"code": -32003, "message": "insufficient credits and no applicable paymaster found"}}`
2. **provider.rs:553-555**: Maps to `ExecuteFromOutsideError::ExecuteFromOutsideNotSupported(_)`
3. **execute_from_outside.rs:61-66, 122-127**: Maps to `ControllerError::PaymasterNotSupported`
4. **session.rs:318 / account-wasm/src/account.rs:668**: Catches `PaymasterNotSupported` and falls back to user-pays flow

## Testing
- ✅ Code compiles successfully
- ✅ All formatting checks pass
- ✅ Pre-commit hooks pass (rustfmt, clippy)
- ✅ Logic verified with unit tests
- ✅ Backward compatible with existing `test_paymaster_fallback` integration test

## Test Plan
- [ ] Verify that when paymaster returns "insufficient credits" error, the transaction falls back to user-pays flow
- [ ] Confirm existing paymaster fallback tests continue to pass
- [ ] Test that other paymaster errors (rate limit, etc.) still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maps paymaster "insufficient credits" RPC errors to `ControllerError::PaymasterNotSupported`, refactors error propagation in outside execution, and adds unit tests validating mappings.
> 
> - **Errors / Mapping**:
>   - Implement `From<ExecuteFromOutsideError>` for `ControllerError` mapping `ExecuteFromOutsideNotSupported(_)` to `PaymasterNotSupported`, others to `PaymasterError`.
>   - Change `ControllerError::PaymasterError` to hold `ExecuteFromOutsideError` without `#[from]`.
> - **Outside Execution**:
>   - In `execute_from_outside_v2` and `execute_from_outside_v3`, replace manual `map_err(ControllerError::PaymasterError)` with `?` to use the new mapping.
> - **Tests**:
>   - Add tests in `errors.rs`, `execute_from_outside.rs`, and `provider.rs` verifying JSON-RPC `-32003` maps to `ExecuteFromOutsideNotSupported` and then to `ControllerError::PaymasterNotSupported`, while other errors map to `PaymasterError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54b1581e044924fd260834c675c0bf09b24ecbc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->