### PR TITLE
fix: defer controller storage persistence until login succeeds

### DIFF
--- a/account-wasm/src/account.rs
+++ b/account-wasm/src/account.rs
@@ -10,7 +10,7 @@ use account_sdk::controller::{Controller, DEFAULT_SESSION_EXPIRATION};
 use account_sdk::errors::ControllerError;
 use account_sdk::session::RevokableSession;
 use account_sdk::storage::selectors::Selectors;
-use account_sdk::storage::StorageBackend;
+use account_sdk::storage::{ControllerMetadata, StorageBackend};
 
 use account_sdk::transaction_waiter::TransactionWaiter;
 use cainome::cairo_serde::NonZero;
@@ -92,7 +92,7 @@ impl CartridgeAccount {
         let rpc_url = Url::parse(&rpc_url)?;
         let username = username.to_lowercase();
 
-        let controller = Controller::new(
+        let mut controller = Controller::new(
             username.clone(),
             class_hash.try_into()?,
             rpc_url,
@@ -102,6 +102,15 @@ impl CartridgeAccount {
         )
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
+
+        controller
+            .storage
+            .set_controller(
+                &controller.chain_id,
+                controller.address,
+                ControllerMetadata::from(&controller),
+            )
+            .expect("Should store controller");
 
         Ok(CartridgeAccountWithMeta::new(controller, cartridge_api_url))
     }
@@ -144,7 +153,7 @@ impl CartridgeAccount {
         let address =
             account_sdk::factory::compute_account_address(class_hash_felt, owner.clone(), salt);
 
-        let controller = Controller::new(
+        let mut controller = Controller::new(
             username.clone(),
             class_hash_felt,
             rpc_url,
@@ -154,6 +163,15 @@ impl CartridgeAccount {
         )
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
+
+        controller
+            .storage
+            .set_controller(
+                &controller.chain_id,
+                controller.address,
+                ControllerMetadata::from(&controller),
+            )
+            .expect("Should store controller");
 
         Ok(CartridgeAccountWithMeta::new(controller, cartridge_api_url))
     }

--- a/account_sdk/src/controller.rs
+++ b/account_sdk/src/controller.rs
@@ -102,12 +102,6 @@ impl Controller {
         ));
         controller.contract = Some(contract);
 
-        // Persist controller metadata immediately to prevent data loss
-        controller
-            .storage
-            .set_controller(&chain_id, address, ControllerMetadata::from(&controller))
-            .map_err(ControllerError::StorageError)?;
-
         // Clears the stored session if it's been revoked
         controller.clear_invalid_session();
 
@@ -165,11 +159,6 @@ impl Controller {
             controller.clone(),
         ));
         controller.contract = Some(contract);
-
-        controller
-            .storage
-            .set_controller(&chain_id, address, ControllerMetadata::from(&controller))
-            .expect("Should store controller");
 
         // Clears the stored session if it's been revoked in a fire-and-forget style when the controller is created (with fromStorage for example).
         // Doing this eagerly prevents having to thread mutability/async through callers that only need an initialized controller.

--- a/account_sdk/src/controller_test.rs
+++ b/account_sdk/src/controller_test.rs
@@ -271,7 +271,7 @@ async fn test_controller_storage() {
     use crate::controller::Controller;
     use crate::signers::Signer;
     use crate::storage::filestorage::FileSystemBackend;
-    use crate::storage::Storage;
+    use crate::storage::{ControllerMetadata, Storage, StorageBackend};
     use crate::tests::ensure_txn;
 
     // Setup temporary directory for file storage
@@ -300,7 +300,7 @@ async fn test_controller_storage() {
     // Create a new controller instance with explicit storage
     // This ensures storage writes go to our temp directory, not wherever
     // CARTRIDGE_STORAGE_PATH might be pointing due to other parallel tests
-    let controller = Controller::new(
+    let mut controller = Controller::new(
         username.clone(),
         deployed.class_hash,
         deployed.rpc_url.clone(),
@@ -311,9 +311,22 @@ async fn test_controller_storage() {
     .await
     .unwrap();
 
-    // Verify that the controller was stored
+    // Controller::new() should NOT persist to storage — callers are responsible
     let storage_file = storage_path.join("@cartridge/active");
-    assert!(storage_file.exists(), "Storage file was not created");
+    assert!(!storage_file.exists(), "Storage file should not exist after Controller::new()");
+
+    // Explicitly persist (as WASM callers do after successful auth)
+    controller
+        .storage
+        .set_controller(
+            &controller.chain_id,
+            controller.address,
+            ControllerMetadata::from(&controller),
+        )
+        .unwrap();
+
+    // Now verify that the controller was stored
+    assert!(storage_file.exists(), "Storage file was not created after explicit set_controller");
 
     // Initialize a new controller from storage using explicit storage path
     let loaded_controller = Controller::from_storage_with_backend(storage)
@@ -595,5 +608,87 @@ async fn test_is_session_expired_states() {
     assert!(
         controller.is_session_expired(),
         "Expired session should be detected as expired"
+    );
+}
+
+#[tokio::test]
+async fn test_controller_new_does_not_persist_to_storage() {
+    use crate::storage::{selectors::Selectors, StorageBackend};
+
+    let runner = KatanaRunner::load();
+    let signer = Signer::new_starknet_random();
+
+    // Deploy first to ensure the runner/proxy is ready
+    let deployed = runner
+        .deploy_controller(
+            "persist_check".to_string(),
+            Owner::Signer(signer.clone()),
+            Version::LATEST,
+        )
+        .await;
+
+    // Now create a new controller (simulating a login attempt that may fail)
+    let controller = Controller::new(
+        "persist_check2".to_string(),
+        CONTROLLERS[&Version::LATEST].hash,
+        deployed.rpc_url.clone(),
+        Owner::Signer(signer),
+        felt!("0xdeadbeef"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Controller::new() should NOT write to storage.
+    // This prevents stale data when login fails (e.g., user cancels WebAuthn).
+    let active = controller.storage.get(&Selectors::active()).unwrap();
+    assert!(
+        active.is_none(),
+        "Controller::new() should not persist to storage"
+    );
+
+    let account = controller
+        .storage
+        .get(&Selectors::account(
+            &controller.address,
+            &controller.chain_id,
+        ))
+        .unwrap();
+    assert!(
+        account.is_none(),
+        "Controller::new() should not persist account metadata to storage"
+    );
+}
+
+#[tokio::test]
+async fn test_controller_new_headless_does_not_persist_to_storage() {
+    use crate::storage::{selectors::Selectors, StorageBackend};
+
+    let runner = KatanaRunner::load();
+    let signer = Signer::new_starknet_random();
+
+    // Deploy first to ensure the runner/proxy is ready
+    let _deployed = runner
+        .deploy_controller(
+            "headless_check".to_string(),
+            Owner::Signer(signer.clone()),
+            Version::LATEST,
+        )
+        .await;
+
+    let controller = Controller::new_headless(
+        "headless_check2".to_string(),
+        CONTROLLERS[&Version::LATEST].hash,
+        runner.rpc_url.clone(),
+        Owner::Signer(signer),
+    )
+    .await
+    .unwrap();
+
+    // new_headless() should NOT write to storage either.
+    let active = controller.storage.get(&Selectors::active()).unwrap();
+    assert!(
+        active.is_none(),
+        "Controller::new_headless() should not persist to storage"
     );
 }

--- a/account_sdk/src/controller_test.rs
+++ b/account_sdk/src/controller_test.rs
@@ -313,7 +313,10 @@ async fn test_controller_storage() {
 
     // Controller::new() should NOT persist to storage — callers are responsible
     let storage_file = storage_path.join("@cartridge/active");
-    assert!(!storage_file.exists(), "Storage file should not exist after Controller::new()");
+    assert!(
+        !storage_file.exists(),
+        "Storage file should not exist after Controller::new()"
+    );
 
     // Explicitly persist (as WASM callers do after successful auth)
     controller
@@ -326,7 +329,10 @@ async fn test_controller_storage() {
         .unwrap();
 
     // Now verify that the controller was stored
-    assert!(storage_file.exists(), "Storage file was not created after explicit set_controller");
+    assert!(
+        storage_file.exists(),
+        "Storage file was not created after explicit set_controller"
+    );
 
     // Initialize a new controller from storage using explicit storage path
     let loaded_controller = Controller::from_storage_with_backend(storage)


### PR DESCRIPTION
## Summary

- Remove early `set_controller` calls from `Controller::new()` and `new_headless()` so that controller metadata is not persisted to localStorage until authentication actually succeeds
- Add explicit `set_controller` in WASM `CartridgeAccount::new()` and `new_headless()` where auth has already completed
- Factory `login`/`api_login` already persist only after WebAuthn succeeds, so no changes needed there

**Problem:** When a user cancels the WebAuthn prompt during login, `Controller::new()` had already written metadata to localStorage. On next page load, `fromStore()` finds stale data and auto-connect gets stuck — the app thinks the user is logged in when they never completed authentication.

## Test plan

- [x] Added `test_controller_new_does_not_persist_to_storage` — verifies `Controller::new()` leaves storage empty
- [x] Added `test_controller_new_headless_does_not_persist_to_storage` — same for `new_headless()`
- [x] Updated `test_controller_storage` (filestorage) to verify explicit persistence after `set_controller`
- [x] `cargo check -p account-wasm` compiles
- [x] `cargo test -p account_sdk` passes
- [ ] Manual test: attempt login → cancel WebAuthn → verify localStorage is clean → reload page → no stuck auto-connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)