### PR TITLE
fix: preserve other controllers on disconnect

### DIFF
--- a/account_sdk/src/storage/localstorage.rs
+++ b/account_sdk/src/storage/localstorage.rs
@@ -1,4 +1,6 @@
-use crate::storage::{StorageBackend, StorageError, StorageValue};
+use crate::storage::{
+    clear_namespaced_storage, StorageBackend, StorageError, StorageValue, CARTRIDGE_STORAGE_PREFIX,
+};
 use async_trait::async_trait;
 use web_sys::window;
 
@@ -42,11 +44,7 @@ impl StorageBackend for LocalStorage {
     }
 
     fn clear(&mut self) -> Result<(), StorageError> {
-        let local_storage = Self::local_storage()?;
-        local_storage
-            .clear()
-            .map_err(|_| StorageError::OperationFailed("clearing localStorage".into()))?;
-        Ok(())
+        clear_namespaced_storage(self, CARTRIDGE_STORAGE_PREFIX)
     }
 
     fn keys(&self) -> Result<Vec<String>, StorageError> {

--- a/account_sdk/src/storage/mod.rs
+++ b/account_sdk/src/storage/mod.rs
@@ -289,6 +289,8 @@ pub enum StorageValue {
     String(String),
 }
 
+pub(crate) const CARTRIDGE_STORAGE_PREFIX: &str = "@cartridge/";
+
 #[async_trait]
 pub trait StorageBackend: Send + Sync {
     fn set(&mut self, key: &str, value: &StorageValue) -> Result<(), StorageError>;
@@ -361,6 +363,21 @@ pub type Storage = localstorage::LocalStorage;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "filestorage"))]
 pub type Storage = filestorage::FileSystemBackend;
+
+pub(crate) fn clear_namespaced_storage(
+    storage: &mut impl StorageBackend,
+    prefix: &str,
+) -> Result<(), StorageError> {
+    let keys = storage.keys()?;
+
+    for key in keys {
+        if key.starts_with(prefix) {
+            storage.remove(&key)?;
+        }
+    }
+
+    Ok(())
+}
 
 /// Clears all persisted storage entries for the backend implementation.
 /// This is used by disconnect and intentionally performs a full clear in the active storage context.

--- a/account_sdk/src/storage/mod.rs
+++ b/account_sdk/src/storage/mod.rs
@@ -364,6 +364,18 @@ pub type Storage = localstorage::LocalStorage;
 #[cfg(all(not(target_arch = "wasm32"), feature = "filestorage"))]
 pub type Storage = filestorage::FileSystemBackend;
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredMultiChainMetadata {
+    username: String,
+    chains: Vec<StoredChainInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredChainInfo {
+    chain_id: Felt,
+    address: Felt,
+}
+
 pub(crate) fn clear_namespaced_storage(
     storage: &mut impl StorageBackend,
     prefix: &str,
@@ -379,11 +391,80 @@ pub(crate) fn clear_namespaced_storage(
     Ok(())
 }
 
-/// Clears all persisted storage entries for the backend implementation.
-/// This is used by disconnect and intentionally performs a full clear in the active storage context.
+/// Clears only the persisted controller entries associated with `address`.
+///
+/// This keeps other logged-in controllers intact while removing all chain-scoped data for the
+/// disconnected address and updating any active/multi-chain metadata that points at it.
 pub(crate) fn clear_controller_storage(
     storage: &mut impl StorageBackend,
-    _address: &Felt,
+    address: &Felt,
 ) -> Result<(), StorageError> {
-    storage.clear()
+    let mut first_err: Option<StorageError> = None;
+
+    let mut record = |res: Result<(), StorageError>| {
+        if let Err(e) = res {
+            if first_err.is_none() {
+                first_err = Some(e);
+            }
+        }
+    };
+
+    match storage.keys() {
+        Ok(keys) => {
+            let account_prefix = format!("@cartridge/account/0x{address:x}/");
+            let session_prefix = format!("@cartridge/session/0x{address:x}/");
+            let deployment_prefix = format!("@cartridge/deployment/0x{address:x}/");
+            let admin_prefix = format!("@cartridge/admin/0x{address:x}/");
+
+            for key in keys {
+                if key.starts_with(&account_prefix)
+                    || key.starts_with(&session_prefix)
+                    || key.starts_with(&deployment_prefix)
+                    || key.starts_with(&admin_prefix)
+                {
+                    record(storage.remove(&key));
+                }
+            }
+        }
+        Err(e) => record(Err(e)),
+    }
+
+    match storage.get(&selectors::Selectors::active()) {
+        Ok(Some(StorageValue::Active(active))) if &active.address == address => {
+            record(storage.remove(&selectors::Selectors::active()));
+        }
+        Ok(_) => {}
+        Err(e) => record(Err(e)),
+    }
+
+    let config_key = selectors::Selectors::multi_chain_config();
+    match storage.get(&config_key) {
+        Ok(Some(StorageValue::String(config_json))) => {
+            if let Ok(mut config) = serde_json::from_str::<StoredMultiChainMetadata>(&config_json) {
+                let before = config.chains.len();
+                config.chains.retain(|chain| chain.address != *address);
+
+                if config.chains.len() != before {
+                    if config.chains.is_empty() {
+                        record(storage.remove(&config_key));
+                    } else {
+                        match serde_json::to_string(&config) {
+                            Ok(updated_json) => record(
+                                storage.set(&config_key, &StorageValue::String(updated_json)),
+                            ),
+                            Err(e) => record(Err(StorageError::Serialization(e))),
+                        }
+                    }
+                }
+            }
+        }
+        Ok(_) => {}
+        Err(e) => record(Err(e)),
+    }
+
+    if let Some(e) = first_err {
+        return Err(e);
+    }
+
+    Ok(())
 }

--- a/account_sdk/src/storage/mod.rs
+++ b/account_sdk/src/storage/mod.rs
@@ -289,6 +289,7 @@ pub enum StorageValue {
     String(String),
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 pub(crate) const CARTRIDGE_STORAGE_PREFIX: &str = "@cartridge/";
 
 #[async_trait]
@@ -376,6 +377,7 @@ struct StoredChainInfo {
     address: Felt,
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 pub(crate) fn clear_namespaced_storage(
     storage: &mut impl StorageBackend,
     prefix: &str,

--- a/account_sdk/src/storage/storage_test.rs
+++ b/account_sdk/src/storage/storage_test.rs
@@ -77,7 +77,7 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_controller_storage_removes_everything() {
+    fn test_clear_controller_storage_is_scoped_and_updates_multi_chain_config() {
         let mut storage = InMemoryBackend::new();
 
         let address_a = felt!("0x111");
@@ -147,6 +147,12 @@ mod tests {
                 &StorageValue::String("deployment_a2".to_string()),
             )
             .unwrap();
+        storage
+            .set(
+                &Selectors::admin(&address_a, "https://x.cartridge.gg"),
+                &StorageValue::String("admin_a".to_string()),
+            )
+            .unwrap();
 
         storage
             .set(
@@ -164,6 +170,12 @@ mod tests {
             .set(
                 &Selectors::deployment(&address_b, &chain_b),
                 &StorageValue::String("deployment_b".to_string()),
+            )
+            .unwrap();
+        storage
+            .set(
+                &Selectors::admin(&address_b, "https://x.cartridge.gg"),
+                &StorageValue::String("admin_b".to_string()),
             )
             .unwrap();
 
@@ -206,17 +218,86 @@ mod tests {
 
         clear_controller_storage(&mut storage, &address_a).unwrap();
 
-        // All stored data is removed.
-        assert_eq!(storage.keys().unwrap().len(), 0);
+        // A's entries are removed across all chains.
+        assert!(storage
+            .get(&Selectors::account(&address_a, &chain_a))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::session(&address_a, &chain_a))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::deployment(&address_a, &chain_a))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::account(&address_a, &chain_a2))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::session(&address_a, &chain_a2))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::deployment(&address_a, &chain_a2))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::admin(&address_a, "https://x.cartridge.gg"))
+            .unwrap()
+            .is_none());
 
-        match storage.get(&Selectors::active()).unwrap() {
-            None => {}
-            other => panic!("unexpected active storage value: {other:?}"),
+        // B's entries remain.
+        assert!(storage
+            .get(&Selectors::account(&address_b, &chain_b))
+            .unwrap()
+            .is_some());
+        assert!(storage
+            .get(&Selectors::session(&address_b, &chain_b))
+            .unwrap()
+            .is_some());
+        assert!(storage
+            .get(&Selectors::deployment(&address_b, &chain_b))
+            .unwrap()
+            .is_some());
+        assert!(storage
+            .get(&Selectors::admin(&address_b, "https://x.cartridge.gg"))
+            .unwrap()
+            .is_some());
+
+        // Global Cartridge metadata remains; disconnect should not log other controllers out.
+        assert!(storage.get("@cartridge/features").unwrap().is_some());
+        assert!(storage
+            .get("@cartridge/https://x.cartridge.gg/active")
+            .unwrap()
+            .is_some());
+        assert!(storage
+            .get("@cartridge/policies/0x111/0x1")
+            .unwrap()
+            .is_some());
+        assert!(storage
+            .get("@cartridge/policies/0x222/0x3")
+            .unwrap()
+            .is_some());
+
+        // Active is removed because it pointed at A.
+        assert!(storage.get(&Selectors::active()).unwrap().is_none());
+
+        // Multi-chain config no longer includes A.
+        match storage.get(&Selectors::multi_chain_config()).unwrap() {
+            Some(StorageValue::String(cfg_json)) => {
+                let cfg: MultiChainMetadata = serde_json::from_str(&cfg_json).unwrap();
+                assert_eq!(cfg.chains.len(), 1);
+                assert_eq!(cfg.chains[0].address, address_b);
+                assert_eq!(cfg.chains[0].chain_id, chain_b);
+            }
+            other => panic!("unexpected multi-chain config storage value: {other:?}"),
         }
     }
 
     #[test]
-    fn test_clear_controller_storage_does_clear_everything_even_for_other_controller() {
+    fn test_clear_controller_storage_does_not_remove_other_active_controller() {
         let mut storage = InMemoryBackend::new();
 
         let address_a = felt!("0x111");
@@ -244,7 +325,7 @@ mod tests {
             )
             .unwrap();
 
-        // Active points at B, but full clear removes all keys anyway.
+        // Active points at B, so clearing A should not change it.
         storage
             .set(
                 &Selectors::active(),
@@ -257,6 +338,22 @@ mod tests {
 
         clear_controller_storage(&mut storage, &address_a).unwrap();
 
-        assert_eq!(storage.keys().unwrap().len(), 0);
+        // A's entries are removed across all chains.
+        assert!(storage
+            .get(&Selectors::account(&address_a, &chain_a))
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .get(&Selectors::account(&address_a, &chain_a2))
+            .unwrap()
+            .is_none());
+
+        match storage.get(&Selectors::active()).unwrap() {
+            Some(StorageValue::Active(active)) => {
+                assert_eq!(active.address, address_b);
+                assert_eq!(active.chain_id, chain_b);
+            }
+            other => panic!("unexpected active storage value: {other:?}"),
+        }
     }
 }

--- a/account_sdk/src/storage/storage_test.rs
+++ b/account_sdk/src/storage/storage_test.rs
@@ -6,7 +6,8 @@ mod tests {
     use crate::storage::inmemory::InMemoryBackend;
     use crate::storage::selectors::Selectors;
     use crate::storage::{
-        clear_controller_storage, ActiveMetadata, StorageBackend, StorageError, StorageValue,
+        clear_controller_storage, clear_namespaced_storage, ActiveMetadata, StorageBackend,
+        StorageError, StorageValue, CARTRIDGE_STORAGE_PREFIX,
     };
     use crate::tests::runners::katana::KatanaRunner;
     use serde_json::json;
@@ -40,6 +41,39 @@ mod tests {
         // test storage.controller to make sure it returns Serialization error
         let result = controller.storage.controller();
         assert!(matches!(result, Err(StorageError::Serialization(_))));
+    }
+
+    #[test]
+    fn test_clear_namespaced_storage_removes_all_cartridge_keys_only() {
+        let mut storage = InMemoryBackend::new();
+
+        storage
+            .set(
+                "@cartridge/active",
+                &StorageValue::String("controller".to_string()),
+            )
+            .unwrap();
+        storage
+            .set(
+                "@cartridge/policies/0x111/0x1",
+                &StorageValue::String("policy".to_string()),
+            )
+            .unwrap();
+        storage
+            .set(
+                "app/non-cartridge",
+                &StorageValue::String("keep".to_string()),
+            )
+            .unwrap();
+
+        clear_namespaced_storage(&mut storage, CARTRIDGE_STORAGE_PREFIX).unwrap();
+
+        assert!(storage.get("@cartridge/active").unwrap().is_none());
+        assert!(storage
+            .get("@cartridge/policies/0x111/0x1")
+            .unwrap()
+            .is_none());
+        assert!(storage.get("app/non-cartridge").unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- restore per-address disconnect cleanup so disconnect removes only the current controller across chains
- keep wasm/browser storage clearing on explicit `@cartridge/*` key removal instead of relying on `localStorage.clear()`
- add regression coverage for scoped disconnect cleanup and Cartridge namespace clearing

## Testing
- cargo test -p account_sdk storage_test