### PR TITLE
fix: surface wasm rpc error messages

### DIFF
--- a/account-wasm/Cargo.toml
+++ b/account-wasm/Cargo.toml
@@ -29,6 +29,7 @@ coset.workspace = true
 futures.workspace = true
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4.3"
+js-sys = "0.3"
 num-traits.workspace = true
 rand = { version = "0.8", features = ["getrandom"] }
 serde = { workspace = true, features = ["derive"] }

--- a/account-wasm/src/account.rs
+++ b/account-wasm/src/account.rs
@@ -28,7 +28,7 @@ use starknet_types_core::felt::Felt;
 use url::Url;
 use wasm_bindgen::prelude::*;
 
-use crate::errors::{ErrorCode, JsControllerError};
+use crate::errors::{ErrorCode, JsControllerError, WasmResult};
 use crate::set_panic_hook;
 use crate::storage::PolicyStorage;
 use crate::sync::WasmMutex;
@@ -191,9 +191,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = exportMetadata)]
-    pub async fn export_metadata(
-        &self,
-    ) -> std::result::Result<ImportedControllerMetadata, JsControllerError> {
+    pub async fn export_metadata(&self) -> WasmResult<ImportedControllerMetadata> {
         set_panic_hook();
 
         let controller = self.controller.lock().await;
@@ -204,7 +202,7 @@ impl CartridgeAccount {
     pub async fn export_authorized_session(
         &self,
         app_id: Option<String>,
-    ) -> std::result::Result<Option<ImportedSessionMetadata>, JsControllerError> {
+    ) -> WasmResult<Option<ImportedSessionMetadata>> {
         set_panic_hook();
 
         let controller = self.controller.lock().await;
@@ -229,7 +227,7 @@ impl CartridgeAccount {
     pub async fn import_session(
         &self,
         imported_session: ImportedSessionMetadata,
-    ) -> std::result::Result<(), JsControllerError> {
+    ) -> WasmResult<()> {
         set_panic_hook();
 
         match (&imported_session.app_id, &imported_session.policies) {
@@ -240,7 +238,8 @@ impl CartridgeAccount {
                     message: "Imported session must include both appId and policies or neither"
                         .to_string(),
                     data: None,
-                });
+                }
+                .into());
             }
         }
 
@@ -269,7 +268,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = disconnect)]
-    pub async fn disconnect(&self) -> std::result::Result<(), JsControllerError> {
+    pub async fn disconnect(&self) -> WasmResult<()> {
         set_panic_hook();
 
         // Policies are stored in localStorage outside of `account_sdk`'s StorageBackend abstraction.
@@ -277,7 +276,9 @@ impl CartridgeAccount {
         let mut controller = self.controller.lock().await;
         let _ = PolicyStorage::clear_for_address(&controller.address);
 
-        controller.disconnect().map_err(JsControllerError::from)
+        controller.disconnect().map_err(JsControllerError::from)?;
+
+        Ok(())
     }
 
     #[wasm_bindgen(js_name = registerSession)]
@@ -288,7 +289,7 @@ impl CartridgeAccount {
         expires_at: u64,
         public_key: JsFelt,
         max_fee: Option<JsFeeEstimate>,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let methods = policies
@@ -347,7 +348,7 @@ impl CartridgeAccount {
         policies: Vec<Policy>,
         expires_at: u64,
         public_key: JsFelt,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let methods = policies
@@ -365,10 +366,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = upgrade)]
-    pub async fn upgrade(
-        &self,
-        new_class_hash: JsFelt,
-    ) -> std::result::Result<JsCall, JsControllerError> {
+    pub async fn upgrade(&self, new_class_hash: JsFelt) -> WasmResult<JsCall> {
         set_panic_hook();
 
         let felt: Felt = new_class_hash.try_into()?;
@@ -381,10 +379,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = register)]
-    pub async fn register(
-        &self,
-        register: JsRegister,
-    ) -> std::result::Result<JsRegisterResponse, JsControllerError> {
+    pub async fn register(&self, register: JsRegister) -> WasmResult<JsRegisterResponse> {
         set_panic_hook();
 
         let register: account_sdk::graphql::registration::register::RegisterInput = register.into();
@@ -405,7 +400,7 @@ impl CartridgeAccount {
         policies: Vec<Policy>,
         expires_at: u64,
         authorize_user_execution: Option<bool>,
-    ) -> std::result::Result<Option<AuthorizedSession>, JsControllerError> {
+    ) -> WasmResult<Option<AuthorizedSession>> {
         set_panic_hook();
 
         let authorize_user_execution = authorize_user_execution.unwrap_or(false);
@@ -417,7 +412,8 @@ impl CartridgeAccount {
                 return Err(JsControllerError::from(ControllerError::ForbiddenEntrypoint(
                     "increaseAllowance and increase_allowance are not allowed in session policies"
                         .to_string(),
-                )));
+                ))
+                .into());
             }
         }
 
@@ -484,9 +480,10 @@ impl CartridgeAccount {
                                     ControllerError::ApproveExecutionRequired {
                                         fee_estimate: Box::new(fee_estimate),
                                     },
-                                ));
+                                )
+                                .into());
                             }
-                            other => return Err(JsControllerError::from(other)),
+                            other => return Err(JsControllerError::from(other).into()),
                         },
                     }
                 }
@@ -522,7 +519,7 @@ impl CartridgeAccount {
                     .remove(&Selectors::session(&address, &chain_id))
                     .map_err(|e| JsControllerError::from(ControllerError::StorageError(e)))?;
 
-                return Err(JsControllerError::from(e));
+                return Err(JsControllerError::from(e).into());
             }
 
             let session_metadata = AuthorizedSession {
@@ -560,11 +557,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = skipSession)]
-    pub async fn skip_session(
-        &self,
-        app_id: String,
-        policies: Vec<Policy>,
-    ) -> std::result::Result<(), JsControllerError> {
+    pub async fn skip_session(&self, app_id: String, policies: Vec<Policy>) -> WasmResult<()> {
         set_panic_hook();
 
         // Convert policies to have authorization explicitly set to false
@@ -601,7 +594,7 @@ impl CartridgeAccount {
         owner: Option<Signer>,
         signer_input: Option<JsAddSignerInput>,
         rp_id: Option<String>,
-    ) -> std::result::Result<(), JsControllerError> {
+    ) -> WasmResult<()> {
         set_panic_hook();
 
         let controller = self.controller.lock().await;
@@ -620,11 +613,12 @@ impl CartridgeAccount {
             self.handle_passkey_creation(rp_id).await?
         } else {
             if owner.is_none() || signer_input.is_none() {
-                return Err(JsControllerError::from(
-                    ControllerError::InvalidResponseData(
+                return Err(
+                    JsControllerError::from(ControllerError::InvalidResponseData(
                         "Owner and signer input are required".to_string(),
-                    ),
-                ));
+                    ))
+                    .into(),
+                );
             }
             (
                 owner.clone().unwrap().try_into()?,
@@ -650,10 +644,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = removeOwner)]
-    pub async fn remove_owner(
-        &mut self,
-        signer: JsRemoveSignerInput,
-    ) -> std::result::Result<(), JsControllerError> {
+    pub async fn remove_owner(&mut self, signer: JsRemoveSignerInput) -> WasmResult<()> {
         set_panic_hook();
 
         let mut controller = self.controller.lock().await;
@@ -698,10 +689,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = createPasskeySigner)]
-    pub async fn create_passkey_signer(
-        &self,
-        rp_id: String,
-    ) -> std::result::Result<JsAddSignerInput, JsControllerError> {
+    pub async fn create_passkey_signer(&self, rp_id: String) -> WasmResult<JsAddSignerInput> {
         set_panic_hook();
 
         let mut controller = self.controller.lock().await;
@@ -712,10 +700,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = estimateInvokeFee)]
-    pub async fn estimate_invoke_fee(
-        &self,
-        calls: Vec<JsCall>,
-    ) -> std::result::Result<JsFeeEstimate, JsControllerError> {
+    pub async fn estimate_invoke_fee(&self, calls: Vec<JsCall>) -> WasmResult<JsFeeEstimate> {
         set_panic_hook();
 
         let calls = calls
@@ -739,7 +724,7 @@ impl CartridgeAccount {
         calls: Vec<JsCall>,
         max_fee: Option<JsFeeEstimate>,
         fee_source: Option<JsFeeSource>,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let calls = calls
@@ -769,7 +754,7 @@ impl CartridgeAccount {
         &self,
         calls: Vec<JsCall>,
         fee_source: Option<JsFeeSource>,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let calls = calls
@@ -794,7 +779,7 @@ impl CartridgeAccount {
         &self,
         calls: Vec<JsCall>,
         fee_source: Option<JsFeeSource>,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let calls = calls
@@ -820,7 +805,7 @@ impl CartridgeAccount {
         app_id: String,
         calls: Vec<JsCall>,
         fee_source: Option<JsFeeSource>,
-    ) -> std::result::Result<JsValue, JsControllerError> {
+    ) -> WasmResult<JsValue> {
         set_panic_hook();
 
         // Convert calls to internal format
@@ -856,12 +841,14 @@ impl CartridgeAccount {
                         // The expired session has policies that would authorize these calls
                         return Err(JsControllerError::from(
                             ControllerError::SessionRefreshRequired,
-                        ));
+                        )
+                        .into());
                     } else {
                         // The expired session doesn't authorize these calls
                         return Err(JsControllerError::from(
                             ControllerError::ManualExecutionRequired,
-                        ));
+                        )
+                        .into());
                     }
                 } else {
                     // Session exists and is not expired - check if policies authorize execution
@@ -871,15 +858,16 @@ impl CartridgeAccount {
                         // Session is valid but policies don't authorize these calls
                         return Err(JsControllerError::from(
                             ControllerError::ManualExecutionRequired,
-                        ));
+                        )
+                        .into());
                     }
                 }
             }
             None => {
                 // No session exists
-                return Err(JsControllerError::from(
-                    ControllerError::ManualExecutionRequired,
-                ));
+                return Err(
+                    JsControllerError::from(ControllerError::ManualExecutionRequired).into(),
+                );
             }
         }
 
@@ -909,7 +897,7 @@ impl CartridgeAccount {
                         .await?;
                     Ok(to_value(&result)?)
                 }
-                other => Err(JsControllerError::from(other)),
+                other => Err(JsControllerError::from(other).into()),
             },
         }
     }
@@ -919,7 +907,7 @@ impl CartridgeAccount {
         &self,
         policies: Vec<Policy>,
         public_key: Option<JsFelt>,
-    ) -> std::result::Result<Option<AuthorizedSession>, JsControllerError> {
+    ) -> WasmResult<Option<AuthorizedSession>> {
         set_panic_hook();
 
         let policies = policies
@@ -943,7 +931,7 @@ impl CartridgeAccount {
         &self,
         app_id: String,
         policies: Vec<Policy>,
-    ) -> std::result::Result<bool, JsControllerError> {
+    ) -> WasmResult<bool> {
         set_panic_hook();
 
         let controller_guard = self.controller.lock().await;
@@ -1068,7 +1056,7 @@ impl CartridgeAccount {
     }
 
     #[wasm_bindgen(js_name = getNonce)]
-    pub async fn get_nonce(&self) -> std::result::Result<JsValue, JsControllerError> {
+    pub async fn get_nonce(&self) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let nonce = self
@@ -1204,7 +1192,7 @@ impl CartridgeAccount {
     pub async fn sign_execute_from_outside(
         &self,
         calls: Vec<JsCall>,
-    ) -> std::result::Result<JsSignedOutsideExecution, JsControllerError> {
+    ) -> WasmResult<JsSignedOutsideExecution> {
         set_panic_hook();
 
         let calls = calls

--- a/account-wasm/src/errors.rs
+++ b/account-wasm/src/errors.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use account_sdk::{
     errors::ControllerError, provider::ExecuteFromOutsideError, signers::DeviceError,
 };
+use js_sys::{Error as NativeJsError, Reflect};
 use serde::Serialize;
 use starknet::{accounts::AccountError, core::types::StarknetError, providers::ProviderError};
 use starknet_types_core::felt::FromStrError;
@@ -16,6 +17,56 @@ pub struct JsControllerError {
     pub code: ErrorCode,
     pub message: String,
     pub data: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct WasmControllerError(JsValue);
+
+pub type WasmResult<T> = std::result::Result<T, WasmControllerError>;
+
+impl JsControllerError {
+    fn into_native_error(self) -> JsValue {
+        let error_value = JsValue::from(NativeJsError::new(&self.message));
+
+        Reflect::set(
+            &error_value,
+            &JsValue::from_str("name"),
+            &JsValue::from_str("JsControllerError"),
+        )
+        .expect("setting error name should succeed");
+        Reflect::set(
+            &error_value,
+            &JsValue::from_str("code"),
+            &JsValue::from_f64(self.code.clone() as u32 as f64),
+        )
+        .expect("setting error code should succeed");
+
+        if let Some(data) = self.data {
+            Reflect::set(
+                &error_value,
+                &JsValue::from_str("data"),
+                &JsValue::from_str(&data),
+            )
+            .expect("setting error data should succeed");
+        }
+
+        error_value
+    }
+}
+
+impl<T> From<T> for WasmControllerError
+where
+    JsControllerError: From<T>,
+{
+    fn from(error: T) -> Self {
+        Self(JsControllerError::from(error).into_native_error())
+    }
+}
+
+impl From<WasmControllerError> for JsValue {
+    fn from(error: WasmControllerError) -> Self {
+        error.0
+    }
 }
 
 impl From<JsError> for JsControllerError {
@@ -559,9 +610,17 @@ impl From<StarknetError> for JsControllerError {
             ),
         };
 
+        let message = if message == "Unexpected error" {
+            data.as_deref()
+                .map(normalize_message)
+                .unwrap_or_else(|| message.to_string())
+        } else {
+            message.to_string()
+        };
+
         JsControllerError {
             code,
-            message: message.to_string(),
+            message,
             data,
         }
     }
@@ -640,6 +699,22 @@ impl fmt::Display for JsControllerError {
 
 impl std::error::Error for JsControllerError {}
 
+fn normalize_message(message: &str) -> String {
+    let trimmed = message.trim();
+    if trimmed.is_empty() {
+        return "Unexpected error".to_string();
+    }
+
+    let mut chars = trimmed.chars();
+    let Some(first) = chars.next() else {
+        return "Unexpected error".to_string();
+    };
+
+    let mut normalized = first.to_uppercase().collect::<String>();
+    normalized.push_str(chars.as_str());
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -660,7 +735,7 @@ mod tests {
         let js_error = JsControllerError::from(generic_error);
 
         assert!(matches!(js_error.code, ErrorCode::StarknetUnexpectedError));
-        assert_eq!(js_error.message, "Unexpected error");
+        assert_eq!(js_error.message, "Some other error");
     }
 
     #[test]
@@ -693,7 +768,7 @@ mod tests {
         let js_error = JsControllerError::from(generic_error);
 
         assert!(matches!(js_error.code, ErrorCode::StarknetUnexpectedError));
-        assert_eq!(js_error.message, "Unexpected error");
+        assert_eq!(js_error.message, "Some other error");
     }
 
     #[test]
@@ -709,7 +784,10 @@ mod tests {
 
         // Should not panic and should have proper error code
         assert!(matches!(js_error.code, ErrorCode::StarknetUnexpectedError));
-        assert_eq!(js_error.message, "Unexpected error");
+        assert_eq!(
+            js_error.message,
+            "Error with \"quotes\" and 'apostrophes' and \n newlines"
+        );
         // Data should be present even with complex strings
         assert!(js_error.data.is_some());
     }
@@ -759,6 +837,20 @@ mod tests {
                 js_error.code
             );
         }
+    }
+
+    #[test]
+    fn test_unexpected_error_message_is_capitalized() {
+        let js_error = JsControllerError::from(StarknetError::UnexpectedError(
+            "checking account deployment".to_string(),
+        ));
+
+        assert!(matches!(js_error.code, ErrorCode::StarknetUnexpectedError));
+        assert_eq!(js_error.message, "Checking account deployment");
+        assert_eq!(
+            js_error.data.as_deref(),
+            Some("checking account deployment")
+        );
     }
 
     #[test]

--- a/account-wasm/src/factory.rs
+++ b/account-wasm/src/factory.rs
@@ -16,7 +16,7 @@ use url::Url;
 use wasm_bindgen::prelude::*;
 
 use crate::account::{CartridgeAccount, CartridgeAccountWithMeta};
-use crate::errors::{ErrorCode, JsControllerError};
+use crate::errors::{ErrorCode, JsControllerError, WasmResult};
 use crate::set_panic_hook;
 use crate::types::import::ImportedControllerMetadata;
 use crate::types::owner::Owner;
@@ -44,7 +44,7 @@ impl ControllerFactory {
     pub async fn from_metadata(
         metadata: ImportedControllerMetadata,
         cartridge_api_url: String,
-    ) -> std::result::Result<CartridgeAccountWithMeta, JsControllerError> {
+    ) -> WasmResult<CartridgeAccountWithMeta> {
         set_panic_hook();
 
         let ImportedControllerMetadata {
@@ -77,7 +77,8 @@ impl ControllerFactory {
                     controller.chain_id
                 ),
                 data: None,
-            });
+            }
+            .into());
         }
 
         controller

--- a/account-wasm/src/multi_chain_account.rs
+++ b/account-wasm/src/multi_chain_account.rs
@@ -6,7 +6,7 @@ use url::Url;
 use wasm_bindgen::prelude::*;
 
 use crate::account::{CartridgeAccount, CartridgeAccountWithMeta};
-use crate::errors::JsControllerError;
+use crate::errors::{JsControllerError, WasmResult};
 use crate::set_panic_hook;
 use crate::sync::WasmMutex;
 use crate::types::owner::Owner;
@@ -132,10 +132,7 @@ impl MultiChainAccount {
 
     /// Adds a new chain configuration
     #[wasm_bindgen(js_name = addChain)]
-    pub async fn add_chain(
-        &self,
-        config: JsChainConfig,
-    ) -> std::result::Result<(), JsControllerError> {
+    pub async fn add_chain(&self, config: JsChainConfig) -> WasmResult<()> {
         let chain_config: ChainConfig = config.try_into().map_err(|e: JsError| {
             JsControllerError::from(ControllerError::InvalidResponseData(format!(
                 "Invalid chain config: {e:?}"
@@ -147,30 +144,28 @@ impl MultiChainAccount {
             .await
             .add_chain(chain_config)
             .await
-            .map_err(JsControllerError::from)
+            .map_err(JsControllerError::from)?;
+
+        Ok(())
     }
 
     /// Removes a chain configuration
     #[wasm_bindgen(js_name = removeChain)]
-    pub async fn remove_chain(
-        &self,
-        chain_id: JsFelt,
-    ) -> std::result::Result<(), JsControllerError> {
+    pub async fn remove_chain(&self, chain_id: JsFelt) -> WasmResult<()> {
         let chain_id_felt: Felt = chain_id.try_into()?;
 
         self.multi_controller
             .lock()
             .await
             .remove_chain(chain_id_felt)
-            .map_err(JsControllerError::from)
+            .map_err(JsControllerError::from)?;
+
+        Ok(())
     }
 
     /// Gets an account instance for a specific chain
     #[wasm_bindgen(js_name = controller)]
-    pub async fn controller(
-        &self,
-        chain_id: JsFelt,
-    ) -> std::result::Result<CartridgeAccount, JsControllerError> {
+    pub async fn controller(&self, chain_id: JsFelt) -> WasmResult<CartridgeAccount> {
         let chain_id_felt: Felt = chain_id.try_into()?;
 
         // Get the controller for this chain

--- a/account-wasm/src/session.rs
+++ b/account-wasm/src/session.rs
@@ -16,7 +16,7 @@ use std::result::Result;
 use url::Url;
 use wasm_bindgen::prelude::*;
 
-use crate::errors::JsControllerError;
+use crate::errors::WasmResult;
 use crate::set_panic_hook;
 use crate::sync::WasmMutex;
 use crate::types::call::JsCall;
@@ -35,7 +35,7 @@ impl CartridgeSessionAccount {
         chain_id: JsFelt,
         session_authorization: Vec<JsFelt>,
         session: Session,
-    ) -> Result<CartridgeSessionAccount, JsControllerError> {
+    ) -> WasmResult<CartridgeSessionAccount> {
         set_panic_hook();
 
         let rpc_url = Url::parse(&rpc_url)?;
@@ -83,7 +83,7 @@ impl CartridgeSessionAccount {
         owner_guid: JsFelt,
         chain_id: JsFelt,
         session: Session,
-    ) -> Result<CartridgeSessionAccount, JsControllerError> {
+    ) -> WasmResult<CartridgeSessionAccount> {
         set_panic_hook();
 
         let rpc_url = Url::parse(&rpc_url)?;
@@ -118,7 +118,7 @@ impl CartridgeSessionAccount {
         )))
     }
 
-    pub async fn sign(&self, hash: JsFelt, calls: Vec<JsCall>) -> Result<Felts, JsControllerError> {
+    pub async fn sign(&self, hash: JsFelt, calls: Vec<JsCall>) -> WasmResult<Felts> {
         set_panic_hook();
 
         let hash = hash.try_into()?;
@@ -137,7 +137,7 @@ impl CartridgeSessionAccount {
         Ok(Felts(res.into_iter().map(Into::into).collect()))
     }
 
-    pub async fn execute(&self, calls: Vec<JsCall>) -> Result<JsValue, JsControllerError> {
+    pub async fn execute(&self, calls: Vec<JsCall>) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let calls = calls
@@ -152,10 +152,7 @@ impl CartridgeSessionAccount {
     }
 
     #[wasm_bindgen(js_name = executeFromOutside)]
-    pub async fn execute_from_outside(
-        &self,
-        calls: Vec<JsCall>,
-    ) -> Result<JsValue, JsControllerError> {
+    pub async fn execute_from_outside(&self, calls: Vec<JsCall>) -> WasmResult<JsValue> {
         set_panic_hook();
 
         let caller = OutsideExecutionCaller::Any;


### PR DESCRIPTION
## Summary
- preserve raw unexpected Starknet RPC messages in the WASM error mapping so callers see messages like "Checking account deployment"
- wrap WASM failures as native JS `Error` objects with `name`, `code`, and optional `data` fields instead of opaque wasm pointers
- update controller and session WASM entrypoints to return through the shared wrapper

## Verification
- cargo check -p account-wasm --lib --features controller_account,session_account
- cargo test -p account-wasm --lib --features controller_account,session_account
- cd account-wasm && ./build.sh