### PR TITLE
fix: wait for ACCEPTED_ON_L2 before calling cartridge mutations

### DIFF
--- a/account-wasm/src/account.rs
+++ b/account-wasm/src/account.rs
@@ -18,7 +18,9 @@ use cainome::cairo_serde::Zeroable;
 use chrono::Utc;
 use serde_wasm_bindgen::to_value;
 use starknet::accounts::ConnectedAccount;
-use starknet::core::types::{BlockId, BlockTag, Call, FeeEstimate, FunctionCall, TypedData, U256};
+use starknet::core::types::{
+    BlockId, BlockTag, Call, FeeEstimate, FunctionCall, TransactionFinalityStatus, TypedData, U256,
+};
 use starknet::signers::SigningKey;
 
 use starknet::core::utils::parse_cairo_short_string;
@@ -214,6 +216,7 @@ impl CartridgeAccount {
 
         TransactionWaiter::new(res.transaction_hash, controller.provider())
             .with_timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT))
+            .with_finality(TransactionFinalityStatus::AcceptedOnL2)
             .wait()
             .await
             .map_err(Into::<ControllerError>::into)?;
@@ -540,6 +543,7 @@ impl CartridgeAccount {
 
         TransactionWaiter::new(tx_result.transaction_hash, controller.provider())
             .with_timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT))
+            .with_finality(TransactionFinalityStatus::AcceptedOnL2)
             .wait()
             .await
             .map_err(Into::<ControllerError>::into)?;
@@ -576,6 +580,7 @@ impl CartridgeAccount {
 
         TransactionWaiter::new(tx_result.transaction_hash, controller.provider())
             .with_timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT))
+            .with_finality(TransactionFinalityStatus::AcceptedOnL2)
             .wait()
             .await
             .map_err(Into::<ControllerError>::into)?;


### PR DESCRIPTION
## Summary

Follow-on to cartridge-gg/controller#2559. On mobile, first tap of **Register Session** was failing with:

> GraphQL API error: \`rpc error: code = Internal desc = signature validation call failed: rpc error: code = InvalidArgument desc = Session not registered\` (path: \`createSession\`)

Retrying worked. Classic RPC replication race.

## Root cause

In \`account-wasm/src/account.rs\`, \`register_session\` submits the on-chain tx, then waits for it, then calls \`register_session_with_cartridge\` (the Cartridge API \`createSession\` mutation that signature-validates the new session on-chain).

\`TransactionWaiter\` without \`.with_finality(...)\` returns as soon as the tx reaches \`PreConfirmed\` (see \`transaction_waiter.rs:175-190\`). That's enough for the client's RPC but the Cartridge API runs its signature validation on a different node; if that node hasn't caught up, \`is_valid_signature\` reports the session as not registered and the mutation fails.

The same pattern (\`TransactionWaiter\` → \`*_with_cartridge\` mutation) exists in \`add_owner\` and \`remove_owner\`, so they likely have the same latent race.

## Fix

Require \`AcceptedOnL2\` finality on the waiter in all three paths. By the time the mutation fires, the tx's effects are on a canonical L2 block and visible across the fleet.

## Risks

- Slower happy path: waiter now blocks until L2 acceptance rather than pre-confirmed. On Starknet mainnet this is typically a few seconds; bounded by the existing \`DEFAULT_TIMEOUT = 30s\`. If L2 acceptance takes longer than that the user sees a timeout instead of a success-then-race — arguably better, but a behavior delta.
- \`revoke_sessions\` also uses a no-finality waiter (line 949) but has no follow-on mutation, so left alone.

## Test plan

- [ ] Mobile: Register Session on first tap succeeds (regression from the reported bug)
- [ ] \`add_owner\` flow still completes
- [ ] \`remove_owner\` flow still completes
- [ ] Timeout behavior reasonable on slow networks

🤖 Generated with [Claude Code](https://claude.com/claude-code)