### PR TITLE
fix: retry rate-limited RPC calls

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,7 +21,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           target: wasm32-unknown-unknown
       - name: Install wasm-pack
-        run: cargo install --locked wasm-pack
+        run: cargo install --locked wasm-pack --version 0.14.0
       - name: Build account-wasm
         working-directory: account-wasm
         run: ./build.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ starknet-types-core = { version = "=0.2.0", features = ["curve", "hash"] }
 chrono = { version = "0.4", features = ["wasmbind", "serde"] }
 
 alloy-signer = "0.12.5"
+ruint = "=1.17.2"
 
 # Compiler optimization when running test to prevent 'locals exceed maximum' error,
 # where a function is using more that the maximum allowed local variables.

--- a/account-wasm/Cargo.toml
+++ b/account-wasm/Cargo.toml
@@ -19,6 +19,7 @@ incremental = false
 
 [dependencies]
 alloy-signer.workspace = true
+ruint.workspace = true
 wee_alloc = { version = "0.4.5", optional = true }
 account_sdk = { workspace = true, features = ["webauthn"] }
 async-trait.workspace = true

--- a/account_sdk/Cargo.toml
+++ b/account_sdk/Cargo.toml
@@ -89,6 +89,7 @@ sha2.workspace = true
 tokio.workspace = true
 alloy-primitives = "0.8"
 alloy-signer.workspace = true
+ruint.workspace = true
 rand = "0.8"
 
 # Include webauthn dependencies when 'webauthn' feature is enabled
@@ -108,6 +109,7 @@ web-sys = { version = "0.3", features = [
     "console",
     "Storage",
     "MessageEvent",
+    "WorkerGlobalScope",
     "Window",
 ] }
 chrono = { workspace = true, features = ["wasmbind"] }

--- a/account_sdk/src/api.rs
+++ b/account_sdk/src/api.rs
@@ -3,9 +3,13 @@ use std::fmt::{self};
 use graphql_client::Response;
 use reqwest::RequestBuilder;
 use serde::{de::DeserializeOwned, Serialize};
+use starknet::providers::ProviderError;
 use url::Url;
 
 use crate::errors::ControllerError;
+use crate::rate_limit::{
+    is_provider_rate_limited, is_reqwest_rate_limited, retry_with_policy, RetryPolicy,
+};
 
 #[derive(Debug)]
 pub struct Client {
@@ -15,15 +19,10 @@ pub struct Client {
 
 impl Client {
     pub fn new(base_url: String) -> Self {
-        let mut client_builder = reqwest::Client::builder();
         #[cfg(not(target_arch = "wasm32"))]
-        {
-            client_builder = client_builder.cookie_store(true);
-        }
+        let client_builder = reqwest::Client::builder().cookie_store(true);
         #[cfg(target_arch = "wasm32")]
-        {
-            client_builder = client_builder;
-        }
+        let client_builder = reqwest::Client::builder();
 
         Self {
             client: client_builder.build().expect("Failed to build client"),
@@ -38,7 +37,18 @@ impl Client {
     {
         let path = "/query";
 
-        let response = self.post(path).json(body).send().await?;
+        let response = retry_with_policy(
+            RetryPolicy::default(),
+            || async {
+                let response = self.post(path).json(body).send().await?;
+                if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    return Err(ControllerError::ProviderError(ProviderError::RateLimited));
+                }
+                Ok(response)
+            },
+            is_controller_rate_limited,
+        )
+        .await?;
 
         let res: Response<R> = response.json().await?;
         if let Some(errors) = res.errors {
@@ -72,6 +82,17 @@ impl Client {
         let mut url = self.base_url.clone();
         url.path_segments_mut().unwrap().extend(path.split('/'));
         url
+    }
+}
+
+fn is_controller_rate_limited(error: &ControllerError) -> bool {
+    match error {
+        ControllerError::ProviderError(error) => is_provider_rate_limited(error),
+        ControllerError::ReqwestError(error) => is_reqwest_rate_limited(error),
+        _ => error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("rate limit"),
     }
 }
 

--- a/account_sdk/src/lib.rs
+++ b/account_sdk/src/lib.rs
@@ -15,6 +15,7 @@ pub mod multi_chain;
 pub mod owner;
 pub mod provider;
 pub mod provider_avnu;
+pub mod rate_limit;
 pub mod session;
 pub mod signers;
 pub mod storage;

--- a/account_sdk/src/provider.rs
+++ b/account_sdk/src/provider.rs
@@ -22,6 +22,18 @@ use url::Url;
 use crate::account::outside_execution::OutsideExecution;
 use crate::constants::VALIDATION_GAS;
 use crate::execute_from_outside::FeeSource;
+use crate::rate_limit::{is_provider_rate_limited, retry_with_policy, RetryPolicy};
+
+macro_rules! retry_provider {
+    ($self:expr, $operation:expr) => {
+        retry_with_policy(
+            $self.retry_policy,
+            || async { $operation.await },
+            is_provider_rate_limited,
+        )
+        .await
+    };
+}
 
 #[cfg(test)]
 #[path = "provider_test.rs"]
@@ -44,6 +56,7 @@ pub trait CartridgeProvider: Provider + Clone {
 pub struct CartridgeJsonRpcProvider {
     inner: JsonRpcClient<HttpTransport>,
     rpc_url: Url,
+    retry_policy: RetryPolicy,
 }
 
 impl Clone for CartridgeJsonRpcProvider {
@@ -51,15 +64,21 @@ impl Clone for CartridgeJsonRpcProvider {
         Self {
             inner: JsonRpcClient::new(HttpTransport::new(self.rpc_url.clone())),
             rpc_url: self.rpc_url.clone(),
+            retry_policy: self.retry_policy,
         }
     }
 }
 
 impl CartridgeJsonRpcProvider {
     pub fn new(rpc_url: Url) -> Self {
+        Self::new_with_retry_policy(rpc_url, RetryPolicy::default())
+    }
+
+    pub fn new_with_retry_policy(rpc_url: Url, retry_policy: RetryPolicy) -> Self {
         Self {
             inner: JsonRpcClient::new(HttpTransport::new(rpc_url.clone())),
             rpc_url,
+            retry_policy,
         }
     }
 }
@@ -74,34 +93,45 @@ impl CartridgeProvider for CartridgeJsonRpcProvider {
         signature: Vec<Felt>,
         fee_source: Option<FeeSource>,
     ) -> Result<ExecuteFromOutsideResponse, ExecuteFromOutsideError> {
-        let request = JsonRpcRequest {
-            id: 1,
-            jsonrpc: "2.0",
-            method: "cartridge_addExecuteOutsideTransaction",
-            params: OutsideExecutionParams {
-                address,
-                outside_execution,
-                signature,
-                fee_source,
-            },
-        };
-
         let client = Client::new();
-        let response = client
-            .post(self.rpc_url.as_str())
-            .header("Content-Type", "application/json")
-            .json(&request)
-            .send()
-            .await?;
+        retry_with_policy(
+            self.retry_policy,
+            || async {
+                let request = JsonRpcRequest {
+                    id: 1,
+                    jsonrpc: "2.0",
+                    method: "cartridge_addExecuteOutsideTransaction",
+                    params: OutsideExecutionParams {
+                        address,
+                        outside_execution: outside_execution.clone(),
+                        signature: signature.clone(),
+                        fee_source,
+                    },
+                };
 
-        let json_response: Value = response.json().await?;
-        let json_rpc_response: JsonRpcResponse<ExecuteFromOutsideResponse> =
-            serde_json::from_value(json_response)?;
+                let response = client
+                    .post(self.rpc_url.as_str())
+                    .header("Content-Type", "application/json")
+                    .json(&request)
+                    .send()
+                    .await?;
 
-        match json_rpc_response {
-            JsonRpcResponse::Success { result, .. } => Ok(result),
-            JsonRpcResponse::Error { error, .. } => Err(error.into()),
-        }
+                if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    return Err(ExecuteFromOutsideError::RateLimitExceeded);
+                }
+
+                let json_response: Value = response.json().await?;
+                let json_rpc_response: JsonRpcResponse<ExecuteFromOutsideResponse> =
+                    serde_json::from_value(json_response)?;
+
+                match json_rpc_response {
+                    JsonRpcResponse::Success { result, .. } => Ok(result),
+                    JsonRpcResponse::Error { error, .. } => Err(error.into()),
+                }
+            },
+            is_execute_from_outside_rate_limited,
+        )
+        .await
     }
 }
 
@@ -109,7 +139,7 @@ impl CartridgeProvider for CartridgeJsonRpcProvider {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Provider for CartridgeJsonRpcProvider {
     async fn spec_version(&self) -> Result<String, ProviderError> {
-        self.inner.spec_version().await
+        retry_provider!(self, self.inner.spec_version())
     }
 
     async fn get_block_with_tx_hashes<B>(
@@ -119,7 +149,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.get_block_with_tx_hashes(block_id).await
+        retry_provider!(self, self.inner.get_block_with_tx_hashes(&block_id))
     }
 
     async fn get_block_with_txs<B>(
@@ -129,7 +159,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.get_block_with_txs(block_id).await
+        retry_provider!(self, self.inner.get_block_with_txs(&block_id))
     }
 
     async fn get_block_with_receipts<B>(
@@ -139,7 +169,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.get_block_with_receipts(block_id).await
+        retry_provider!(self, self.inner.get_block_with_receipts(&block_id))
     }
 
     async fn get_state_update<B>(
@@ -149,7 +179,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.get_state_update(block_id).await
+        retry_provider!(self, self.inner.get_state_update(&block_id))
     }
 
     async fn get_storage_at<A, K, B>(
@@ -163,9 +193,11 @@ impl Provider for CartridgeJsonRpcProvider {
         K: AsRef<Felt> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner
-            .get_storage_at(contract_address, key, block_id)
-            .await
+        retry_provider!(
+            self,
+            self.inner
+                .get_storage_at(&contract_address, &key, &block_id)
+        )
     }
 
     async fn get_transaction_status<H>(
@@ -175,7 +207,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         H: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_transaction_status(transaction_hash).await
+        retry_provider!(self, self.inner.get_transaction_status(&transaction_hash))
     }
 
     async fn get_transaction_by_hash<H>(
@@ -185,7 +217,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         H: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_transaction_by_hash(transaction_hash).await
+        retry_provider!(self, self.inner.get_transaction_by_hash(&transaction_hash))
     }
 
     async fn get_transaction_by_block_id_and_index<B>(
@@ -196,9 +228,11 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner
-            .get_transaction_by_block_id_and_index(block_id, index)
-            .await
+        retry_provider!(
+            self,
+            self.inner
+                .get_transaction_by_block_id_and_index(&block_id, index)
+        )
     }
 
     async fn get_transaction_receipt<H>(
@@ -208,7 +242,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         H: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_transaction_receipt(transaction_hash).await
+        retry_provider!(self, self.inner.get_transaction_receipt(&transaction_hash))
     }
 
     async fn get_class<B, H>(
@@ -220,7 +254,7 @@ impl Provider for CartridgeJsonRpcProvider {
         B: AsRef<BlockId> + Send + Sync,
         H: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_class(block_id, class_hash).await
+        retry_provider!(self, self.inner.get_class(&block_id, &class_hash))
     }
 
     async fn get_class_hash_at<B, A>(
@@ -232,9 +266,10 @@ impl Provider for CartridgeJsonRpcProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<Felt> + Send + Sync,
     {
-        self.inner
-            .get_class_hash_at(block_id, contract_address)
-            .await
+        retry_provider!(
+            self,
+            self.inner.get_class_hash_at(&block_id, &contract_address)
+        )
     }
 
     async fn get_class_at<B, A>(
@@ -246,14 +281,14 @@ impl Provider for CartridgeJsonRpcProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_class_at(block_id, contract_address).await
+        retry_provider!(self, self.inner.get_class_at(&block_id, &contract_address))
     }
 
     async fn get_block_transaction_count<B>(&self, block_id: B) -> Result<u64, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.get_block_transaction_count(block_id).await
+        retry_provider!(self, self.inner.get_block_transaction_count(&block_id))
     }
 
     async fn call<R, B>(&self, request: R, block_id: B) -> Result<Vec<Felt>, ProviderError>
@@ -261,7 +296,7 @@ impl Provider for CartridgeJsonRpcProvider {
         R: AsRef<FunctionCall> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.call(request, block_id).await
+        retry_provider!(self, self.inner.call(&request, &block_id))
     }
 
     async fn estimate_fee<R, S, B>(
@@ -275,10 +310,11 @@ impl Provider for CartridgeJsonRpcProvider {
         S: AsRef<[SimulationFlagForEstimateFee]> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        let mut estimates = self
-            .inner
-            .estimate_fee(request, &simulation_flags, block_id)
-            .await?;
+        let mut estimates = retry_provider!(
+            self,
+            self.inner
+                .estimate_fee(&request, &simulation_flags, &block_id)
+        )?;
 
         // Add VALIDATION_GAS if skip validate is enabled
         if simulation_flags
@@ -303,23 +339,23 @@ impl Provider for CartridgeJsonRpcProvider {
         M: AsRef<MsgFromL1> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
     {
-        self.inner.estimate_message_fee(message, block_id).await
+        retry_provider!(self, self.inner.estimate_message_fee(&message, &block_id))
     }
 
     async fn block_number(&self) -> Result<u64, ProviderError> {
-        self.inner.block_number().await
+        retry_provider!(self, self.inner.block_number())
     }
 
     async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, ProviderError> {
-        self.inner.block_hash_and_number().await
+        retry_provider!(self, self.inner.block_hash_and_number())
     }
 
     async fn chain_id(&self) -> Result<Felt, ProviderError> {
-        self.inner.chain_id().await
+        retry_provider!(self, self.inner.chain_id())
     }
 
     async fn syncing(&self) -> Result<SyncStatusType, ProviderError> {
-        self.inner.syncing().await
+        retry_provider!(self, self.inner.syncing())
     }
 
     async fn get_events(
@@ -328,9 +364,11 @@ impl Provider for CartridgeJsonRpcProvider {
         continuation_token: Option<String>,
         chunk_size: u64,
     ) -> Result<EventsPage, ProviderError> {
-        self.inner
-            .get_events(filter, continuation_token, chunk_size)
-            .await
+        retry_provider!(
+            self,
+            self.inner
+                .get_events(filter.clone(), continuation_token.clone(), chunk_size)
+        )
     }
 
     async fn get_nonce<B, A>(&self, block_id: B, contract_address: A) -> Result<Felt, ProviderError>
@@ -338,7 +376,7 @@ impl Provider for CartridgeJsonRpcProvider {
         B: AsRef<BlockId> + Send + Sync,
         A: AsRef<Felt> + Send + Sync,
     {
-        self.inner.get_nonce(block_id, contract_address).await
+        retry_provider!(self, self.inner.get_nonce(&block_id, &contract_address))
     }
 
     async fn add_invoke_transaction<I>(
@@ -382,7 +420,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         H: AsRef<Felt> + Send + Sync,
     {
-        self.inner.trace_transaction(transaction_hash).await
+        retry_provider!(self, self.inner.trace_transaction(&transaction_hash))
     }
 
     async fn simulate_transactions<B, T, S>(
@@ -396,10 +434,11 @@ impl Provider for CartridgeJsonRpcProvider {
         T: AsRef<[BroadcastedTransaction]> + Send + Sync,
         S: AsRef<[SimulationFlag]> + Send + Sync,
     {
-        let mut simuations = self
-            .inner
-            .simulate_transactions(block_id, transactions, &simulation_flags)
-            .await?;
+        let mut simuations = retry_provider!(
+            self,
+            self.inner
+                .simulate_transactions(&block_id, &transactions, &simulation_flags)
+        )?;
 
         // Add VALIDATION_GAS if skip validate is enabled
         if simulation_flags
@@ -425,7 +464,7 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         B: AsRef<ConfirmedBlockId> + Send + Sync,
     {
-        self.inner.trace_block_transactions(block_id).await
+        retry_provider!(self, self.inner.trace_block_transactions(&block_id))
     }
 
     async fn batch_requests<R>(
@@ -435,14 +474,14 @@ impl Provider for CartridgeJsonRpcProvider {
     where
         R: AsRef<[ProviderRequestData]> + Send + Sync,
     {
-        self.inner.batch_requests(requests).await
+        retry_provider!(self, self.inner.batch_requests(&requests))
     }
 
     async fn get_messages_status(
         &self,
         transaction_hash: Hash256,
     ) -> Result<Vec<starknet::core::types::MessageStatus>, ProviderError> {
-        self.inner.get_messages_status(transaction_hash).await
+        retry_provider!(self, self.inner.get_messages_status(transaction_hash))
     }
 
     async fn get_storage_proof<B, H, A, K>(
@@ -458,14 +497,15 @@ impl Provider for CartridgeJsonRpcProvider {
         A: AsRef<[Felt]> + Send + Sync,
         K: AsRef<[starknet::core::types::ContractStorageKeys]> + Send + Sync,
     {
-        self.inner
-            .get_storage_proof(
-                block_id,
-                class_hashes,
-                contract_addresses,
-                contracts_storage_keys,
+        retry_provider!(
+            self,
+            self.inner.get_storage_proof(
+                &block_id,
+                &class_hashes,
+                &contract_addresses,
+                &contracts_storage_keys,
             )
-            .await
+        )
     }
 }
 
@@ -570,6 +610,14 @@ impl From<reqwest::Error> for ExecuteFromOutsideError {
         ExecuteFromOutsideError::ProviderError(
             JsonRpcClientError::<reqwest::Error>::TransportError(error).into(),
         )
+    }
+}
+
+pub fn is_execute_from_outside_rate_limited(error: &ExecuteFromOutsideError) -> bool {
+    match error {
+        ExecuteFromOutsideError::RateLimitExceeded => true,
+        ExecuteFromOutsideError::ProviderError(error) => is_provider_rate_limited(error),
+        _ => false,
     }
 }
 

--- a/account_sdk/src/provider_avnu.rs
+++ b/account_sdk/src/provider_avnu.rs
@@ -6,7 +6,10 @@ use starknet::core::types::{Call, Felt};
 use starknet::providers::jsonrpc::JsonRpcResponse;
 use url::Url;
 
-use crate::provider::{ExecuteFromOutsideError, ExecuteFromOutsideResponse};
+use crate::provider::{
+    is_execute_from_outside_rate_limited, ExecuteFromOutsideError, ExecuteFromOutsideResponse,
+};
+use crate::rate_limit::{retry_with_policy, RetryPolicy};
 
 /// JSON-RPC request for AVNU paymaster API
 #[derive(Debug, Serialize)]
@@ -27,6 +30,7 @@ pub struct AvnuPaymasterProvider {
     paymaster_url: Url,
     client: Client,
     api_key: Option<String>,
+    retry_policy: RetryPolicy,
 }
 
 impl AvnuPaymasterProvider {
@@ -35,6 +39,7 @@ impl AvnuPaymasterProvider {
             paymaster_url,
             client: Client::new(),
             api_key: None,
+            retry_policy: RetryPolicy::default(),
         }
     }
 
@@ -44,7 +49,13 @@ impl AvnuPaymasterProvider {
             paymaster_url,
             client: Client::new(),
             api_key: Some(api_key),
+            retry_policy: RetryPolicy::default(),
         }
+    }
+
+    pub fn with_retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
     }
 
     /// Execute a direct transaction through the AVNU paymaster.
@@ -62,43 +73,55 @@ impl AvnuPaymasterProvider {
         &self,
         request: ExecuteRawRequest,
     ) -> Result<ExecuteRawResponse, ExecuteFromOutsideError> {
-        let rpc_request = AvnuJsonRpcRequest {
-            id: 1,
-            jsonrpc: "2.0",
-            method: "paymaster_executeDirectTransaction",
-            params: request,
-        };
+        retry_with_policy(
+            self.retry_policy,
+            || async {
+                let rpc_request = AvnuJsonRpcRequest {
+                    id: 1,
+                    jsonrpc: "2.0",
+                    method: "paymaster_executeDirectTransaction",
+                    params: request.clone(),
+                };
 
-        let mut req = self
-            .client
-            .post(self.paymaster_url.as_str())
-            .header("Content-Type", "application/json");
+                let mut req = self
+                    .client
+                    .post(self.paymaster_url.as_str())
+                    .header("Content-Type", "application/json");
 
-        // Add API key header if present (required for sponsored transactions)
-        if let Some(api_key) = &self.api_key {
-            req = req.header("x-paymaster-api-key", api_key);
-        }
+                // Add API key header if present (required for sponsored transactions)
+                if let Some(api_key) = &self.api_key {
+                    req = req.header("x-paymaster-api-key", api_key);
+                }
 
-        let response = req.json(&rpc_request).send().await?;
+                let response = req.json(&rpc_request).send().await?;
 
-        let json_rpc_response: JsonRpcResponse<ExecuteRawResponse> = response.json().await?;
+                if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                    return Err(ExecuteFromOutsideError::RateLimitExceeded);
+                }
 
-        match json_rpc_response {
-            JsonRpcResponse::Success { result, .. } => Ok(result),
-            JsonRpcResponse::Error { error, .. } => Err(error.into()),
-        }
+                let json_rpc_response: JsonRpcResponse<ExecuteRawResponse> =
+                    response.json().await?;
+
+                match json_rpc_response {
+                    JsonRpcResponse::Success { result, .. } => Ok(result),
+                    JsonRpcResponse::Error { error, .. } => Err(error.into()),
+                }
+            },
+            is_execute_from_outside_rate_limited,
+        )
+        .await
     }
 }
 
 /// Request for paymaster_executeDirectTransaction
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecuteRawRequest {
     pub transaction: ExecuteRawTransactionParams,
     pub parameters: ExecutionParameters,
 }
 
 /// Transaction parameters for direct execute
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ExecuteRawTransactionParams {
     #[serde(rename = "invoke")]
@@ -107,7 +130,7 @@ pub enum ExecuteRawTransactionParams {
 
 /// Parameters for a direct invoke transaction
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirectInvokeParams {
     #[serde_as(as = "UfeHex")]
     pub user_address: Felt,
@@ -115,7 +138,7 @@ pub struct DirectInvokeParams {
 }
 
 /// Execution parameters
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "version")]
 pub enum ExecutionParameters {
     #[serde(rename = "0x1")]
@@ -128,7 +151,7 @@ pub enum ExecutionParameters {
 
 /// Fee mode for the transaction
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum FeeMode {
     Default {
@@ -155,7 +178,7 @@ pub enum TipPriority {
 }
 
 /// Time bounds for the transaction
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimeBounds {
     pub execute_after: u64,
     pub execute_before: u64,

--- a/account_sdk/src/rate_limit.rs
+++ b/account_sdk/src/rate_limit.rs
@@ -1,0 +1,139 @@
+use std::future::Future;
+use std::time::Duration;
+
+use starknet::providers::ProviderError;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy {
+    pub max_attempts: u32,
+    pub base_delay: Duration,
+    pub max_delay: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 4,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(8),
+        }
+    }
+}
+
+impl RetryPolicy {
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        let multiplier = 1u32.checked_shl(attempt).unwrap_or(u32::MAX);
+        let delay = self.base_delay.saturating_mul(multiplier);
+        delay.min(self.max_delay)
+    }
+}
+
+pub async fn retry_with_policy<T, E, F, Fut, I>(
+    policy: RetryPolicy,
+    mut operation: F,
+    is_rate_limited: I,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    I: Fn(&E) -> bool,
+{
+    let mut attempt = 0;
+
+    loop {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) if is_rate_limited(&error) && attempt + 1 < policy.max_attempts => {
+                sleep(policy.delay_for_attempt(attempt)).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+pub async fn sleep(delay: Duration) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        tokio::time::sleep(delay).await;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use wasm_bindgen::JsCast;
+        use web_sys::WorkerGlobalScope;
+
+        let mut cb = |resolve: js_sys::Function, _reject: js_sys::Function| {
+            if let Ok(worker_scope) = js_sys::global().dyn_into::<WorkerGlobalScope>() {
+                worker_scope
+                    .set_timeout_with_callback_and_timeout_and_arguments_0(
+                        &resolve,
+                        delay.as_millis() as i32,
+                    )
+                    .expect("should register `setTimeout`");
+            } else {
+                web_sys::window()
+                    .unwrap()
+                    .set_timeout_with_callback_and_timeout_and_arguments_0(
+                        &resolve,
+                        delay.as_millis() as i32,
+                    )
+                    .expect("should register `setTimeout`");
+            }
+        };
+        let promise = js_sys::Promise::new(&mut cb);
+        wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
+    }
+}
+
+pub fn is_provider_rate_limited(error: &ProviderError) -> bool {
+    match error {
+        ProviderError::RateLimited => true,
+        ProviderError::Other(other) => {
+            let message = other.to_string().to_ascii_lowercase();
+            message.contains("rate limit")
+                || message.contains("too many requests")
+                || message.contains("429")
+        }
+        ProviderError::StarknetError(starknet_error) => {
+            let message = starknet_error.to_string().to_ascii_lowercase();
+            message.contains("rate limit") || message.contains("too many requests")
+        }
+        ProviderError::ArrayLengthMismatch => false,
+    }
+}
+
+pub fn is_reqwest_rate_limited(error: &reqwest::Error) -> bool {
+    error.status() == Some(reqwest::StatusCode::TOO_MANY_REQUESTS)
+        || error
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("rate limit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delay_is_exponential_and_capped() {
+        let policy = RetryPolicy {
+            max_attempts: 4,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(2),
+        };
+
+        assert_eq!(policy.delay_for_attempt(0), Duration::from_millis(500));
+        assert_eq!(policy.delay_for_attempt(1), Duration::from_secs(1));
+        assert_eq!(policy.delay_for_attempt(2), Duration::from_secs(2));
+        assert_eq!(policy.delay_for_attempt(3), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn detects_provider_rate_limit_errors() {
+        assert!(is_provider_rate_limited(&ProviderError::RateLimited));
+        assert!(!is_provider_rate_limited(
+            &ProviderError::ArrayLengthMismatch
+        ));
+    }
+}

--- a/account_sdk/src/transaction_waiter.rs
+++ b/account_sdk/src/transaction_waiter.rs
@@ -8,6 +8,7 @@ use starknet::core::types::{
 use starknet::providers::{Provider, ProviderError};
 
 use crate::errors::ControllerError;
+use crate::rate_limit::is_provider_rate_limited;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionWaitingError {
@@ -211,6 +212,8 @@ where
                 },
 
                 Err(ProviderError::StarknetError(StarknetError::TransactionHashNotFound)) => {}
+
+                Err(e) if is_provider_rate_limited(&e) => {}
 
                 Err(e) => {
                     return Err(TransactionWaitingError::Provider(e));


### PR DESCRIPTION
## Summary
- add bounded retry/backoff support for explicit RPC/API rate-limit errors in account_sdk
- wrap idempotent Starknet provider reads/estimates, GraphQL API calls, AVNU direct transaction calls, and execute-outside HTTP calls
- keep standard starknet_add*Transaction provider methods single-shot to avoid duplicate non-idempotent submissions on ambiguous transport responses
- treat provider rate limits while waiting for transaction finality like a transient wait condition

## Review notes
- During review, a full test rerun exposed duplicate submit risk when generic retry wrapped add_declare/add_invoke/add_deploy_account. I removed retries from those standard submission methods; only explicit HTTP 429 custom paths retry.

## Validation
- cargo test -p account_sdk --lib
- cd account-wasm && ./build.sh

## Notes
- WASM build still emits existing account-wasm dead-code/lifetime warnings; the new account_sdk unused-mut warning was fixed.